### PR TITLE
Censor rows

### DIFF
--- a/R/pip.R
+++ b/R/pip.R
@@ -98,6 +98,9 @@ pip <- function(country   = "all",
     out <- out[out$pop_data_level == svy_coverage, ]
   }
 
+  # Censor values
+  out <- censor_rows(out, lkup[["censored"]])
+
   # ADD FIX FOR MEDIAN WHEN INTERPOLATING
   # median <- dist_stats[["median"]]/(data_mean/requested_mean)
 

--- a/R/pip.R
+++ b/R/pip.R
@@ -83,7 +83,7 @@ pip <- function(country   = "all",
     out$poverty_line <- povline
 
     out <- aggregate_by_group(df = out,
-                              group_lkup = lkups[["pop_region"]])
+                              group_lkup = lkup[["pop_region"]])
 
     return(out)
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -148,3 +148,29 @@ add_dist_stats <- function(df, dist_stats) {
   return(df)
 }
 
+#' Censor rows
+#' Censor statistics based on a pre-defined censor table.
+#' @param df data.table: Table to censor, e.g output from `pip()`.
+#' @param censored_table data.table: Censor table.
+#' @return data.table
+#' @noRd
+censor_rows <- function(df, censored_table) {
+
+  df$tmp_id <-
+    sprintf('%s_%s_%s',
+            df$country_code, df$reporting_year,
+            df$welfare_type)
+
+  if (any(df$tmp_id %in% censored_table$id)) {
+    for (i in seq_len(nrow(df))) {
+      for (y in seq_len(nrow(censored_table))) {
+        if (df$tmp_id[i] == censored_table$id[y]) {
+          df[[censored_table$statistic[y]]][i] <- NA
+        }
+      }
+    }
+  }
+  df$tmp_id <- NULL
+
+  return(df)
+}

--- a/tests/testthat/test-censor_rows.R
+++ b/tests/testthat/test-censor_rows.R
@@ -1,0 +1,34 @@
+# Constants
+censored_table <- data.frame(
+  country_code = c(rep('XYZ', 3), 'WLD'),
+  survey_acronym = c(rep('HBS', 3), NA),
+  reporting_year = c(2000, 2000, 2008, 2018),
+  welfare_type = c(rep('consumption', 3), NA),
+  statistic = c('mld', 'gini', 'median', 'headcount')
+)
+censored_table$id <-
+  sprintf('%s_%s_%s',
+          censored_table$country_code,
+          censored_table$reporting_year,
+          censored_table$welfare_type)
+df <- data.frame(
+  country_code = c(rep('XYZ', 3), 'WLD'),
+  survey_acronym = c(rep('HBS', 3), NA),
+  reporting_year = c(2000, 2008, 2018, 2018),
+  welfare_type = c(rep('consumption', 3), NA),
+  median = c(2.5, 3, 2, 10),
+  gini = c(0.5, 0.4, 0.45, 0.4),
+  polarization = c(0.5, 0.4, 0.45, 0.5),
+  mld = c(0.5, 0.4, 0.45, 0.51),
+  headcount = c(3, 2.5, 2, 400)
+)
+
+test_that("collapse_rows() works correctly", {
+  res <- censor_rows(df, censored_table)
+  expect_identical(dim(res), dim(df))
+  expect_equal(res$gini, c(NA, 0.40, 0.45, 0.40))
+  expect_equal(res$median, c(2.5, NA, 2.0, 10.0))
+  expect_equal(res$mld, c(NA, 0.4, 0.45, 0.51))
+  expect_equal(res$headcount, c(3, 2.5, 2, NA))
+  expect_equal(res$polarization, c(0.5, 0.4, 0.45, 0.50))
+})


### PR DESCRIPTION
Hi  @tonyfujs, 

This PR adds a `censor_rows()` function in order to censor specific statistics for specific country/years.  I'll work separately on adding a censored table to the pipeline outputs. 

Note that you will need to modify the temp preparation file for the code to work. Add something like: 

```
# Create test censored table
censored <- data.frame(
  country_code = c(rep('AGO', 3), 'WLD'),
  reporting_year = c(2000, 2000, 2008, 2018),
  welfare_type = c(rep('consumption', 3), ''),
  statistic = c('mld', 'gini', 'median', 'mean')
)
censored$id <-
  sprintf('%s_%s_%s',
          censored$country_code,
          censored$reporting_year,
          censored$welfare_type)


# Create list of lkups ----------------------------------------------------


lkups <- list(svy_lkup       = svy_lkup,
              ref_lkup       = ref_lkup,
              dist_stats     = dist_stats,
              pop_region     = pop_region,
              censored       = censored,
              query_controls = query_controls)
```

And then test with: 

```
x = pip(country = 'AGO', povline = 1.9, lkup = lkups, paths = paths)
x$mld
x$gini
x$median
```

Closes #16
Closes #19
