### PR TITLE
Clean function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,8 @@ Imports:
     magrittr,
     ggplot2,
     plotly,
-    readr
+    readr,
+    dplyr
 Depends: 
     R (>= 2.10)
 VignetteBuilder: knitr

--- a/R/clean_api_data.R
+++ b/R/clean_api_data.R
@@ -57,7 +57,7 @@ clean_api_data <- function(data_folder_root) {
 
   versions <- fs::dir_ls(path = data_folder_root,
                          type = "directory",
-                         recursive = FALSE)
+                         recurse = FALSE)
 
   query_controls <- list(
     country = country,

--- a/R/clean_api_data.R
+++ b/R/clean_api_data.R
@@ -1,0 +1,87 @@
+clean_api_data <- function(data_folder_root) {
+  paths <- fs::dir_ls(paste0(data_folder_root, "/survey_data"), recurse = FALSE, type = "file")
+  paths_ids <- basename(paths)
+  paths_ids <- tools::file_path_sans_ext(paths_ids)
+
+  # Clean svy_lkup
+  svy_lkup <- fst::read_fst(paste0(data_folder_root, "/estimations/survey_means.fst"))
+  # TEMP cleaning - START
+  svy_lkup <- svy_lkup[!is.na(svy_lkup$survey_mean_ppp), ]
+  svy_lkup <- svy_lkup[!is.na(svy_lkup$ppp), ]
+  svy_lkup <- svy_lkup[svy_lkup$cache_id %in% paths_ids, ]
+  # TEMP cleaning - END
+  svy_lkup$path <- paste0(data_folder_root, "survey_data/", svy_lkup$cache_id, ".fst")
+  svy_lkup <- data.table::setDT(svy_lkup)
+
+  # Clean ref_lkup
+  ref_lkup <- fst::read_fst(paste0(data_folder_root, "/estimations/interpolated_means.fst"))
+  # TEMP cleaning - START
+  ref_lkup <- ref_lkup[!is.na(ref_lkup$predicted_mean_ppp), ]
+  ref_lkup <- ref_lkup[!is.na(ref_lkup$ppp), ]
+  ref_lkup <- ref_lkup[ref_lkup$cache_id %in% paths_ids, ]
+  # TEMP cleaning - END
+  ref_lkup$path <- paste0(data_folder_root, "survey_data/", ref_lkup$cache_id, ".fst")
+  ref_lkup <- data.table::setDT(ref_lkup)
+  ref_lkup <- ref_lkup %>%
+    dplyr::mutate(
+      interpolation_id = paste(country_code, reporting_year, pop_data_level, sep = "_")
+    )
+  # Load dist_stats
+  dist_stats <- fst::read_fst(paste0(data_folder_root, "/estimations/dist_stats.fst"))
+  dist_stats <- data.table::setDT(dist_stats)
+
+  # Clean pop_region
+  pop_region <- fst::read_fst(paste0(data_folder_root, "/_aux/pop-region.fst")) %>%
+    dplyr::rename(reporting_year = year, reporting_pop = pop)
+  pop_region <- data.table::setDT(pop_region)
+
+  # Create query controls
+  country <- list(values = c("all", sort(unique(c(svy_lkup$country_code, ref_lkup$country_code)))),
+                  type = "character")
+  year <- list(values = c("all", sort(unique(c(svy_lkup$reporting_year, ref_lkup$reporting_year)))),
+               type = "character")
+  povline <- list(values = c(min = 0, max = 100),
+                  type = "numeric")
+  popshare <- list(values = c(min = 0, max = 1),
+                   type = "numeric")
+  fill_gaps <- aggregate <- list(values = c(TRUE, FALSE),
+                                 type = "logical")
+  group_by <- list(values = c("wb", "inc"),
+                   type = "character")
+  welfare_type <- list(values = c("all", sort(unique(c(svy_lkup$welfare_type, ref_lkup$welfare_type)))),
+                       type = "character")
+  svy_coverage <- list(values = c("all", sort(unique(c(svy_lkup$pop_data_level, ref_lkup$pop_data_level)))),
+                       type = "character")
+  ppp <- list(values = c(min = 0, max = 1000000), # CHECK THE VALUE OF MAX
+              type = "numeric")
+
+  versions <- fs::dir_ls(path = data_folder_root,
+                         type = "directory",
+                         recursive = FALSE)
+
+  query_controls <- list(
+    country = country,
+    year = year,
+    povline = povline,
+    popshare = popshare,
+    fill_gaps = fill_gaps,
+    aggregate = aggregate,
+    group_by = group_by,
+    welfare_type = welfare_type,
+    svy_coverage = svy_coverage,
+    ppp = ppp,
+    version = versions
+  )
+
+  # Create list of lkups
+
+  lkups <- list(svy_lkup       = svy_lkup,
+                ref_lkup       = ref_lkup,
+                dist_stats     = dist_stats,
+                pop_region     = pop_region,
+                query_controls = query_controls,
+                data_root      = data_folder_root)
+
+  return(lkups)
+
+}

--- a/R/get_pip_version.R
+++ b/R/get_pip_version.R
@@ -1,23 +1,40 @@
 #' Return the versions of the pip packages used for computations
 #'
+#' @param pip_packages character: Custom packages powering the API
+#' @param data_folder_root character: Root path of data folder
+#' @param valid_params list: Valid API query parameters
 #'
 #' @return list
 #' @export
 #'
-get_pip_version <- function() {
+get_pip_version <- function(pip_packages = c("pipapi", "wbpip"),
+                            data_folder_root,
+                            valid_params) {
 
-  pip_packages <- c("pipapi", "wbpip")
-  resp <- lapply(pip_packages, retrieve_version)
-  names(resp) <- pip_packages
+  # Package versions
+  pkg <- lapply(pip_packages, retrieve_pkg_version)
+  names(pkg) <- pip_packages
 
-  return(resp)
+  # Data version
+  data <- fs::dir_ls(path = data_folder_root,
+                     type = "directory",
+                     recurse = TRUE)
+
+  return(
+    list(
+      valid_query_parameters = valid_params,
+      packages_version = pkg,
+      data_versions    = data
+    )
+  )
 }
 
-retrieve_version <- function(package) {
+retrieve_pkg_version <- function(package) {
   desc <- read.dcf(system.file("DESCRIPTION", package = package))
-  resp <- list(
+  pkg <- list(
       version = unname(desc[1,"Version"])#,
       # built = unname(desc[1,"Built"])
     )
-  return(resp)
+
+  return(pkg)
 }

--- a/R/ui_functions.R
+++ b/R/ui_functions.R
@@ -8,15 +8,15 @@
 #'
 ui_hp_stacked <- function(povline = 1.9,
                           lkup) {
-  out <- pip(country = "all",
-             year    = "all",
-             povline = povline,
-             lkup = lkups,
-             fill_gaps = TRUE,
-             aggregate = TRUE,
-             group_by = TRUE,
+  out <- pip(country      = "all",
+             year         = "all",
+             povline      = povline,
+             lkup         = lkup,
+             fill_gaps    = TRUE,
+             aggregate    = TRUE,
+             group_by     = TRUE,
              svy_coverage = "national",
-             paths = paths)
+             paths        = paths)
 
   out <- out[, .(region_code, reporting_year, poverty_line, pop_in_poverty)]
   return(out)

--- a/inst/plumber/v1/openapi.yaml
+++ b/inst/plumber/v1/openapi.yaml
@@ -11,9 +11,9 @@ paths:
         default:
           description: Default response.
       parameters: []
-  /api/v1/version:
+  /api/v1/info:
     get:
-      summary: ' Returns the version to the code and data that powers the API'
+      summary: ' Returns information about the API and the available data versions'
       responses:
         default:
           description: Default response.

--- a/inst/plumber/v1/plumber.R
+++ b/inst/plumber/v1/plumber.R
@@ -5,7 +5,7 @@
 
 library(pipapi)
 
-lkups <- clean_api_data(data_folder_root = "../../../TEMP/output/20210401/")
+lkups <- pipapi:::clean_api_data(data_folder_root = "../../../TEMP/output/20210401/")
 
 
 # API filters -------------------------------------------------------------

--- a/inst/plumber/v1/plumber.R
+++ b/inst/plumber/v1/plumber.R
@@ -5,7 +5,7 @@
 
 library(pipapi)
 
-source("../../../TEMP/TEMP_clean_data.R")
+lkups <- clean_api_data(data_folder_root = "../../../TEMP/output/20210401/")
 
 
 # API filters -------------------------------------------------------------
@@ -54,11 +54,12 @@ function(){
   Sys.info()
 }
 
-# #* Return PIP version
-# #* @get /api/v1/version
-# function() {
-#   pipapi::get_pip_version()
-# }
+#* Return PIP information
+#* @get /api/v1/info
+function() {
+  pipapi::get_pip_version(data_folder_root = lkups$data_root,
+                          valid_params     = lkups$query_controls)
+}
 
 #* Return CPI table
 #* @get /api/v1/get-cpi
@@ -96,7 +97,6 @@ function(req) {
   # browser()
   params <- req$argsQuery
   params$lkup <- lkups
-  params$paths <- paths
 
   do.call(pipapi::pip, params)
 }

--- a/man/get_pip_version.Rd
+++ b/man/get_pip_version.Rd
@@ -4,7 +4,18 @@
 \alias{get_pip_version}
 \title{Return the versions of the pip packages used for computations}
 \usage{
-get_pip_version()
+get_pip_version(
+  pip_packages = c("pipapi", "wbpip"),
+  data_folder_root,
+  valid_params
+)
+}
+\arguments{
+\item{pip_packages}{character: Custom packages powering the API}
+
+\item{data_folder_root}{character: Root path of data folder}
+
+\item{valid_params}{list: Valid API query parameters}
 }
 \value{
 list

--- a/tests/testthat/test-plumber.R
+++ b/tests/testthat/test-plumber.R
@@ -1,0 +1,34 @@
+# Setup by starting APIs
+root_path <- "http://localhost"
+# CAUTION: TESTS WILL CURRENTLY FAILS DUE TO PATH ISSUES WITH THE DATA FOLDER
+# IN `plumber.R#8: lkups <- pipapi:::clean_api_data(data_folder_root = "../../../TEMP/output/20210401/")`
+# api1 <- callr::r_bg(
+#   function() {
+#     plbr_file <- system.file("plumber", "v1", "plumber.R", package = "pipapi")
+#     pr <- plumber::plumb(plbr_file)
+#     pr$run(port = 8000)
+#   }
+# )
+#
+# Sys.sleep(10)
+
+# test_that("API is alive", {
+#   skip('API fails to build in background process')
+#   expect_true(api1$is_alive())
+# })
+#
+# test_that("Health check works", {
+#   # Send API request
+#   r <- httr::GET(root_path, port = 8000, path = "api/v1/health-check")
+#
+#   # Check response
+#   skip('API fails to build in background process')
+#   expect_equal(r$status_code, 200)
+#   skip('API fails to build in background process')
+#   expect_equal(httr::content(r, encoding = "UTF-8"), list("PIP API is running"))
+# })
+#
+# teardown({
+#   api1$kill()
+# })
+


### PR DESCRIPTION
Improve a few things:

- fix a couple of bugs
- data prep is now self-contained in it's own function (No more our of sync TEMP_clean_data file to pass around)
- add new `/info` endpoint that provides information about:
  - package version
  - data version
  - accepted query parameters
- add framework for unit testing endpoints in a parallel R process