### PR TITLE
Set API version to pkg version

### DIFF
--- a/inst/plumber/v1/endpoints.R
+++ b/inst/plumber/v1/endpoints.R
@@ -1,5 +1,4 @@
 #* @apiTitle PIP API
-#* @apiVersion 0.0.1
 #* @apiDescription This API powers computations of statistics available at
 #* pip.worldbank.org
 

--- a/inst/plumber/v1/plumber.R
+++ b/inst/plumber/v1/plumber.R
@@ -28,4 +28,8 @@ plumber::pr(endpoints_path) %>%
   }) %>%
   plumber::pr_hook("exit", function() {
     log_info('Bye bye: {proc.time()[["elapsed"]]}')
+  }) %>%
+  plumber::pr_set_api_spec(api = function(spec) {
+    spec$info$version <- utils::packageVersion("pipapi") %>% as.character()
+    spec
   })


### PR DESCRIPTION
Hi @tonyfujs, 

Small thing, but I thought it could be useful to keep the package and API versions in sync. This PR ensure that be setting the API version to the installed version of pipapi at run time. 

Inspired by https://community.rstudio.com/t/programmatically-set-plumber-apiversion-to-package-version/114476/2 

Closes #87.