### PR TITLE
Aux refactor

### DIFF
--- a/R/utils-plumber.R
+++ b/R/utils-plumber.R
@@ -159,7 +159,7 @@ serializer_switch <- function() {
           sfn <- jsonlite::toJSON
         } else if (format == "csv") {
           type <- "text/csv; charset=UTF-8"
-          sfn <- readr::format_csv
+          sfn <- function(x) readr::format_csv(x, na = "")
         } else if (format == "rds") {
           type <- "application/rds"
           sfn <- function(x) base::serialize(x, NULL)

--- a/inst/plumber/v1/endpoints.R
+++ b/inst/plumber/v1/endpoints.R
@@ -163,42 +163,19 @@ function(req) {
 
 
 
-#* Return CPI table
-#* @get /api/v1/cpi
+#* Return auxiliary data table
+#* @get /api/v1/aux
+#* @param table:[chr] Auxiliary data table to be returned
 #* @param format:[chr] Response format. Options are of "json", "csv", or "rds".
 #* @serializer switch
 function(req) {
+  # browser()
   out <- pipapi::get_aux_table(
     data_dir = lkups$data_root,
-    table = "cpi")
+    table = req$args$table)
   attr(out, "serialize_format") <- req$argsQuery$format
   out
 }
-
-#* Return list of countries
-#* @get /api/v1/countries
-#* @param format:[chr] Response format. Options are of "json", "csv", or "rds".
-#* @serializer switch
-function(req) {
-  out <- pipapi::get_aux_table(
-    data_dir = lkups$data_root,
-    table = "countries")
-  attr(out, "serialize_format") <- req$argsQuery$format
-  out
-}
-
-#* Return list of regions
-#* @get /api/v1/regions
-#* @param format:[chr] Response format. Options are of "json", "csv", or "rds".
-#* @serializer switch
-function(req) {
-  out <- pipapi::get_aux_table(
-    data_dir = lkups$data_root,
-    table = "regions")
-  attr(out, "serialize_format") <- req$argsQuery$format
-  out
-}
-
 
 # UI endpoints: Homepage --------------------------------------------------
 


### PR DESCRIPTION
Small changes that:
* Implement a new /aux endpoint 
* Encode missings as empty string in csv response

I haven't implemented any validation of the possible aux tables for now. It will require some modification of the `create_lookups()` function, so I'll do it once the `data_version` branch has been merged to avoid potential conflicts.