### PR TITLE
finalize /aux endpoint

### DIFF
--- a/R/create_lkups.R
+++ b/R/create_lkups.R
@@ -175,6 +175,10 @@ create_lkups <- function(data_dir, versions) {
       # 'wb_region_code', 'interpolation_id'
     )
 
+  # Create list of available auxiliary data tables
+  aux_tables <- tools::file_path_sans_ext(list.files(paste0(data_dir, "/_aux")))
+  aux_tables <- sort(aux_tables)
+
   # Create list of query controls
   query_controls <-
     create_query_controls(
@@ -192,6 +196,7 @@ create_lkups <- function(data_dir, versions) {
     pip_cols = pip_cols,
     query_controls = query_controls,
     data_root = data_dir,
+    aux_tables = aux_tables,
     interpolation_list = interpolation_list
   )
 

--- a/inst/plumber/v1/endpoints.R
+++ b/inst/plumber/v1/endpoints.R
@@ -206,9 +206,14 @@ function(req) {
   params$lkup <- lkups$versions_paths[[params$version]]
   params$format <- NULL
   params$version <- NULL
-  out <- pipapi::get_aux_table(
-    data_dir = params$lkup$data_root,
-    table = req$args$table)
+
+  if (is.null(req$args$table)) {
+    out <- lkup$aux_tables
+  } else {
+    out <- pipapi::get_aux_table(
+      data_dir = params$lkup$data_root,
+      table = req$args$table)
+  }
   attr(out, "serialize_format") <- req$argsQuery$format
   out
 }

--- a/inst/plumber/v1/endpoints.R
+++ b/inst/plumber/v1/endpoints.R
@@ -208,7 +208,7 @@ function(req) {
   params$version <- NULL
 
   if (is.null(req$args$table)) {
-    out <- lkup$aux_tables
+    out <- params$lkup$aux_tables
   } else {
     out <- pipapi::get_aux_table(
       data_dir = params$lkup$data_root,


### PR DESCRIPTION
Complete the /aux endpoint. New behavior is:
* `api/v1/aux` returns list of available auxiliary tables
* `api/v1/aux?table={table_name} returns the specified auxiliary data