### PR TITLE
Use identical response types

### DIFF
--- a/R/fg_pip.R
+++ b/R/fg_pip.R
@@ -80,17 +80,6 @@ fg_pip <- function(country,
         popshare = popshare
       )
 
-      # Ensure that tmp_metadata has a single row
-      # vars_to_collapse <- c(
-      #   "survey_id", "cache_id", "surveyid_year", "survey_year",
-      #   "survey_acronym", "survey_coverage", "survey_comparability",
-      #   "comparable_spell", "welfare_type",
-      #   "gd_type", "mean", "predicted_mean_ppp", "survey_mean_lcu", "survey_mean_ppp",
-      #   "interpolation_id", "path", "cpi"
-      # )
-      #
-      # tmp_metadata[, vars_to_collapse] <- NA
-      #
       # Handle multiple distribution types (for aggregated distributions)
       if (length(unique(tmp_metadata$distribution_type)) > 1) {
         tmp_metadata$distribution_type <- "mixed"
@@ -104,30 +93,36 @@ fg_pip <- function(country,
       }
 
 
-      # tmp_metadata <- collapse_rows(
-      #   df = tmp_metadata,
-      #   vars = vars_to_collapse,
-      #   na_var = "survey_mean_ppp"
-      # )
       results_subset[[ctry_year_id]] <- tmp_metadata
     }
 
     out[[svy_id]] <- results_subset
   }
 
-  # out <- purrr::flatten(out)
   out <- unlist(out, recursive = FALSE)
   out <- data.table::rbindlist(out)
 
+  # Set collapse vars to NA (by type)
+  # vars_to_collapse <- c(
+  #   "survey_id", "cache_id", "surveyid_year", "survey_year",
+  #   "survey_acronym", "survey_coverage", "survey_comparability",
+  #   "comparable_spell", "welfare_type",
+  #   "gd_type", "mean", "predicted_mean_ppp", "survey_mean_lcu", "survey_mean_ppp",
+  #   "interpolation_id", "path", "cpi"
+  # )
+  vars_to_collapse_real <- c("survey_year", "predicted_mean_ppp", "survey_mean_lcu",
+                             "survey_mean_ppp", "cpi")
+  vars_to_collapse_int <- c("surveyid_year", "survey_comparability")
+  vars_to_collapse_char <-
+    c("survey_id", "cache_id", "survey_acronym", "survey_coverage",
+      "comparable_spell", "welfare_type", "gd_type", "interpolation_id",
+      "path")
+
+  out[, vars_to_collapse_char] <- NA_character_
+  out[, vars_to_collapse_int] <- NA_integer_
+  out[, vars_to_collapse_real] <- NA_real_
+
   # Ensure that out does not have duplicates
-  vars_to_collapse <- c(
-    "survey_id", "cache_id", "surveyid_year", "survey_year",
-    "survey_acronym", "survey_coverage", "survey_comparability",
-    "comparable_spell", "welfare_type",
-    "gd_type", "mean", "predicted_mean_ppp", "survey_mean_lcu", "survey_mean_ppp",
-    "interpolation_id", "path", "cpi"
-  )
-  out[, vars_to_collapse] <- NA
   out <- unique(out)
 
   return(out)

--- a/tests/testthat/test-pip.R
+++ b/tests/testthat/test-pip.R
@@ -5,15 +5,14 @@ files <- sub("[.]fst", "", list.files("../testdata/app_data/20210401/survey_data
 lkups <- create_versioned_lkups(Sys.getenv("PIPAPI_DATA_ROOT_FOLDER"))
 lkups <- lkups$versions_paths$latest_release
 
-
 test_that("Reporting level filtering is working", {
   reporting_levels <- c("national", "urban", "rural", "all")
   tmp <- lapply(reporting_levels,
                 function(x) {
-                  pip(country="CHN",
-                      year="2008",
-                      povline=1.9,
-                      popshare=NULL,
+                  pip(country = "CHN",
+                      year = "2008",
+                      povline = 1.9,
+                      popshare = NULL,
                       welfare_type = "all",
                       reporting_level = x,
                       fill_gaps = FALSE,
@@ -35,13 +34,6 @@ test_that("Reporting level filtering is working", {
   expect_equal(nrow(tmp$all), 3)
   expect_equal(sort(tmp$all$pop_data_level), c("national", "rural", "urban"))
   })
-
-
-
-
-
-
-
 
 # Use only test data
 lkups$svy_lkup <- lkups$svy_lkup[(cache_id %in% files | country_code == "AGO")]
@@ -74,7 +66,7 @@ test_that("returned columns are the same for all non-group_by queries", {
   tmp3 <- pip('AGO', 2050, lkup = lkups)
   expect_identical(names(tmp1), names(tmp2))
   expect_identical(names(tmp1), names(tmp3))
-  skip("collapsed columns (e.g. survey_year, cpi) are converted to character")
+  # skip("collapsed columns (e.g. survey_year, cpi) are converted to character")
   expect_identical(sapply(tmp1, class), sapply(tmp2, class))
   expect_identical(sapply(tmp1, class), sapply(tmp3, class))
 })


### PR DESCRIPTION
@tonyfujs ,

This ensures that fg_pip() returns the same types for all columns as rg_pip(). Note: It also removes `mean` from the list of variables to set to NA. `mean`  should be reported even for gap filled years I think? But please check.  

Closes #70