### PR TITLE
Add /data-timestamp endpoint

### DIFF
--- a/inst/plumber/v1/endpoints.R
+++ b/inst/plumber/v1/endpoints.R
@@ -128,6 +128,14 @@ function() {
 #   )
 # }
 
+#* Check status of API
+#* @get /api/v1/data-timestamp
+#* @param version:[chr] Data version. Defaults to most recent version. See api/v1/versions
+function(req) {
+  dir <- lkups$versions_paths[[req$argsQuery$version]]$data_root
+  readLines(sprintf("%s/data_update_timestamp.txt", dir))
+}
+
 #* Return PIP information
 #* @get /api/v1/pip-info
 function(req) {


### PR DESCRIPTION
Hi @tonyfujs 

I added this so that it will be easier for us to check if the data has been copied to the VM. Not sure about the endpoint or file naming here. Also not sure if this should be one file per version folder (like it is currently) or just one file for all potential version folders. Currently it has to live within the 20210401 folder however to make sure that it is copied to the blob storage and the VM. 

Sync with TFS to get the file locally. It was created with 

```r
dir <- paste0(Sys.getenv("PIPAPI_DATA_ROOT_FOLDER"), "/20210401/")
writeLines(as.character(Sys.time()), paste0(dir, "data_update_timestamp.txt"))
```