### PR TITLE
Censor recent years

### DIFF
--- a/R/pip.R
+++ b/R/pip.R
@@ -17,6 +17,7 @@
 #' @param lkup list: A list of lkup tables
 #' @param debug logical: If TRUE poverty calculations from `wbpip` will run in
 #'   debug mode
+#' @param censor logical: Triggers censoring of country/year statistics
 #'
 #' @return data.table
 #' @examples
@@ -61,7 +62,8 @@ pip <- function(country = "all",
                 reporting_level = c("all", "national", "rural", "urban"),
                 ppp = NULL,
                 lkup,
-                debug = FALSE) {
+                debug = FALSE,
+                censor = TRUE) {
 
   welfare_type <- match.arg(welfare_type)
   reporting_level <- match.arg(reporting_level)
@@ -132,7 +134,9 @@ pip <- function(country = "all",
       group_lkup = lkup[["pop_region"]]
     )
     # Censor regional values
+    if (censor == TRUE) {
     out <- censor_rows(out, lkup[["censored"]], type = "region")
+    }
 
     return(out)
   }
@@ -151,14 +155,12 @@ pip <- function(country = "all",
   }
 
   # Censor country values
-  if (group_by == "none") {
+  if (censor == TRUE) {
     out <- censor_rows(out, lkup[["censored"]], type = "country")
   }
 
   # Select columns
-  if (group_by == "none") {
     out <- out[, .SD, .SDcols = lkup$pip_cols]
-  }
 
   return(out)
 }

--- a/R/pip.R
+++ b/R/pip.R
@@ -93,7 +93,6 @@ pip <- function(country = "all",
     )
   } else {
     # Compute survey year stats
-    # tictoc::tic("pip")
     out <- rg_pip(
       country = country,
       year = year,
@@ -105,14 +104,10 @@ pip <- function(country = "all",
       lkup = lkup,
       debug = debug
     )
-    # Logging
-    # end_pip <- tictoc::toc(quiet = TRUE)
-    # logger::log_info('pip: {round(end_pip$toc - end_pip$tic, digits = getOption("digits", 6))}')
   }
 
   # return empty dataframe if no metadata is found
   if (nrow(out) == 0) {
-    # out <- out[, .SD, .SDcols = cols]
     return(out)
   }
 
@@ -134,8 +129,8 @@ pip <- function(country = "all",
       group_lkup = lkup[["pop_region"]]
     )
     # Censor regional values
-    if (censor == TRUE) {
-    out <- censor_rows(out, lkup[["censored"]], type = "region")
+    if (censor) {
+      out <- censor_rows(out, lkup[["censored"]], type = "region")
     }
 
     return(out)
@@ -155,12 +150,12 @@ pip <- function(country = "all",
   }
 
   # Censor country values
-  if (censor == TRUE) {
+  if (censor) {
     out <- censor_rows(out, lkup[["censored"]], type = "country")
   }
 
   # Select columns
-    out <- out[, .SD, .SDcols = lkup$pip_cols]
+  out <- out[, .SD, .SDcols = lkup$pip_cols]
 
   return(out)
 }

--- a/R/ui_functions.R
+++ b/R/ui_functions.R
@@ -12,6 +12,11 @@ ui_hp_stacked <- function(povline = 1.9,
 
   ref_years <- sort(unique(lkup$ref_lkup$reporting_year))
   ref_years <- ref_years[!ref_years %in% c(1981:1989)]
+  ### TMP FIX START
+  ### Ad hoc filtering of recent years
+  ### To be removed once full censoring is correctly implemented
+  ref_years <- ref_years[!ref_years %in% c(2019, 2020)]
+  ### TMP FIX END
 
   out <- pip(
     country = "all",

--- a/R/ui_functions.R
+++ b/R/ui_functions.R
@@ -25,7 +25,8 @@ ui_hp_stacked <- function(povline = 1.9,
     lkup = lkup,
     fill_gaps = TRUE,
     group_by = "wb",
-    reporting_level = "national"
+    reporting_level = "national",
+    censor = FALSE
   )
 
   # out <- pip_grp(

--- a/man/pip.Rd
+++ b/man/pip.Rd
@@ -15,7 +15,8 @@ pip(
   reporting_level = c("all", "national", "rural", "urban"),
   ppp = NULL,
   lkup,
-  debug = FALSE
+  debug = FALSE,
+  censor = TRUE
 )
 }
 \arguments{
@@ -44,6 +45,8 @@ sub-groups}
 
 \item{debug}{logical: If TRUE poverty calculations from \code{wbpip} will run in
 debug mode}
+
+\item{censor}{logical: Triggers censoring of country/year statistics}
 }
 \value{
 data.table

--- a/tests/testthat/test-pip-local.R
+++ b/tests/testthat/test-pip-local.R
@@ -214,7 +214,13 @@ test_that("Imputation is working", {
     lkup = lkups
   )
   # Why is this correct? E.g. tmp %>% group_by(country_code) %>% summarise(n = n())
-  expect_equal(nrow(tmp), 6817)
+  expect_equal(nrow(tmp), 7097)
+  # Expect there are no duplicates
+  expect_equal(nrow(unique(tmp[, c("country_code",
+                                     "reporting_year",
+                                     "reporting_level",
+                                     "welfare_type")])),
+               nrow(tmp))
   # expect_equal(nrow(tmp), 182)
 })
 
@@ -273,7 +279,8 @@ test_that("Regional aggregations are working", {
     year = "2000",
     group_by = "wb",
     povline = 3.5,
-    lkup = lkups
+    lkup = lkups,
+    censor = FALSE
   )
 
   expect_equal(nrow(tmp), 8)


### PR DESCRIPTION
This PR:
* Add a temporary, ad hoc censoring of recent years for the `ui_hp_stacked()`
* Add a new `censor` parameter in `pip()` to trun censoring on and off
* Update a couple of unit tests