### PR TITLE
Fix dist stats when fill_gaps = TRUE

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,11 +6,12 @@
 
 - Increase maximum limit for `povline` parameter from 100 to 10 000
 - Remove unnecessary columns from API response
-- Add estimation_type and distribution_type to the API response when fill_gaps=TRUE
+- Add estimation_type and distribution_type to the API response when `fill_gaps=TRUE`
 
 ## Bug fixes
 
 - Duplicates are no longer created when `fill_gaps=TRUE`
+- Fix bug where distributional stats were incorrectly returned as missing for extrapolated surveys when `fill_gaps=TRUE`
 
 # pipapi 0.0.1
 

--- a/R/fg_pip.R
+++ b/R/fg_pip.R
@@ -99,8 +99,11 @@ fg_pip <- function(country,
   out <- unlist(out, recursive = FALSE)
   out <- data.table::rbindlist(out)
 
-  # Collapse duplicated cache_id's
-  out <- collapse_rows(out, "cache_id")
+  # Set cache_id to a modified version of data_interpolation_id
+  out$cache_id <-
+    ifelse(grepl("[|]", out$data_interpolation_id),
+           gsub(paste0("_", out$reporting_level, collapse = '|'), '', out$data_interpolation_id),
+           out$cache_id)
 
   # Set collapse vars to NA (by type)
   vars_to_collapse_real <- c("survey_year",
@@ -109,6 +112,7 @@ fg_pip <- function(country,
                              "survey_mean_ppp",
                              "survey_median_lcu",
                              "survey_median_ppp",
+                             # "median",
                              "cpi",
                              "display_cp")
 

--- a/R/fg_pip.R
+++ b/R/fg_pip.R
@@ -99,6 +99,9 @@ fg_pip <- function(country,
   out <- unlist(out, recursive = FALSE)
   out <- data.table::rbindlist(out)
 
+  # Collapse duplicated cache_id's
+  out <- collapse_rows(out, "cache_id")
+
   # Set collapse vars to NA (by type)
   vars_to_collapse_real <- c("survey_year",
                              "predicted_mean_ppp",
@@ -113,7 +116,7 @@ fg_pip <- function(country,
                             "survey_comparability")
 
   vars_to_collapse_char <- c("survey_id",
-                             "cache_id",
+                             #"cache_id",
                              "survey_acronym",
                              "survey_coverage",
                              "comparable_spell",
@@ -122,7 +125,6 @@ fg_pip <- function(country,
                              #"estimation_type",
                              #"distribution_type",
                              "path")
-
   out[, vars_to_collapse_char] <- NA_character_
   out[, vars_to_collapse_int] <- NA_integer_
   out[, vars_to_collapse_real] <- NA_real_

--- a/R/fg_pip.R
+++ b/R/fg_pip.R
@@ -99,7 +99,9 @@ fg_pip <- function(country,
   out <- unlist(out, recursive = FALSE)
   out <- data.table::rbindlist(out)
 
-  # Set cache_id to a modified version of data_interpolation_id
+  # Modify cache_id
+  # * Ensures that cache_id is unique for both extrapolated and interpolated surveys
+  # * Ensures that cache_id can be kept as an output of fg_pip() while still removing duplicated rows
   out$cache_id <-
     ifelse(grepl("[|]", out$data_interpolation_id),
            gsub(paste0("_", out$reporting_level, collapse = '|'), '', out$data_interpolation_id),

--- a/R/fg_pip.R
+++ b/R/fg_pip.R
@@ -104,7 +104,7 @@ fg_pip <- function(country,
   # * Ensures that cache_id can be kept as an output of fg_pip() while still removing duplicated rows
   out$cache_id <-
     ifelse(grepl("[|]", out$data_interpolation_id),
-           gsub(paste0("_", out$reporting_level, collapse = '|'), '', out$data_interpolation_id),
+           gsub(paste0("_", unique(out$reporting_level), collapse = '|'), '', out$data_interpolation_id),
            out$cache_id)
 
   # Set collapse vars to NA (by type)

--- a/R/pip.R
+++ b/R/pip.R
@@ -114,6 +114,9 @@ pip <- function(country = "all",
   # Handles aggregated distributions
   if (reporting_level %in% c("national", "all")) {
     out <- add_agg_stats(out)
+    if (reporting_level == "national") {
+      out <- out[reporting_level == "national"]
+    }
   }
 
   # **** TO BE REMOVED **** REMOVAL STARTS HERE

--- a/R/utils.R
+++ b/R/utils.R
@@ -149,10 +149,11 @@ get_svy_data <- function(svy_id,
 add_dist_stats <- function(df, dist_stats) {
   # Keep only relevant columns
   cols <- c(
-    "country_code",
-    "reporting_year",
-    "welfare_type",
-    "reporting_level",
+    "cache_id",
+    # "country_code",
+    # "reporting_year",
+    # "welfare_type",
+    # "reporting_level",
     "gini",
     "polarization",
     "mld",
@@ -164,7 +165,7 @@ add_dist_stats <- function(df, dist_stats) {
   # data.table::setnames(dist_stats, "survey_median_ppp", "median")
 
   df <- dist_stats[df,
-                   on = .(country_code, reporting_year, welfare_type, reporting_level),
+                   on = .(cache_id), #.(country_code, reporting_year, welfare_type, reporting_level),
                    allow.cartesian = TRUE
   ]
 
@@ -174,15 +175,16 @@ add_dist_stats <- function(df, dist_stats) {
 #' Collapse rows
 #' @return data.table
 #' @noRd
-collapse_rows <- function(df, vars, na_var) {
+collapse_rows <- function(df, vars, na_var = NULL) {
   tmp_vars <- lapply(df[, .SD, .SDcols = vars], unique, collapse = "|")
   tmp_vars <- lapply(tmp_vars, paste, collapse = "|")
   tmp_var_names <- names(df[, .SD, .SDcols = vars])
-  df[[na_var]] <- NA_real_
+  if (!is.null(na_var)) df[[na_var]] <- NA_real_
   for (tmp_var in seq_along(tmp_vars)) {
     df[[tmp_var_names[tmp_var]]] <- tmp_vars[[tmp_var]]
   }
   df <- unique(df)
+  return(df)
 }
 
 #' Censor rows

--- a/R/utils.R
+++ b/R/utils.R
@@ -153,7 +153,7 @@ add_dist_stats <- function(df, dist_stats) {
     # "country_code",
     # "reporting_year",
     # "welfare_type",
-    # "reporting_level",
+    "reporting_level",
     "gini",
     "polarization",
     "mld",
@@ -165,7 +165,7 @@ add_dist_stats <- function(df, dist_stats) {
   # data.table::setnames(dist_stats, "survey_median_ppp", "median")
 
   df <- dist_stats[df,
-                   on = .(cache_id), #.(country_code, reporting_year, welfare_type, reporting_level),
+                   on = .(cache_id, reporting_level), #.(country_code, reporting_year, welfare_type, reporting_level),
                    allow.cartesian = TRUE
   ]
 

--- a/tests/testthat/test-pip-local.R
+++ b/tests/testthat/test-pip-local.R
@@ -271,6 +271,39 @@ test_that("imputation is working for extrapolated aggregate distribution", {
   # expect_equal(tmp$mean[tmp$reporting_level == "national"], 62.5904793524725 * 12 / 365)
 })
 
+test_that("Distributional stats are correct for interpolated/extrapolated reporting years",{
+
+  # Extrapolation (one year)
+  tmp1 <- pip("AGO", year = 1981, fill_gaps = TRUE, lkup = lkups)
+  tmp2 <- pip("AGO", year = 2000, fill_gaps = FALSE, lkup = lkups)
+  expect_equal(tmp1$gini, tmp2$gini)
+  expect_equal(tmp2$median, tmp2$median)
+  expect_equal(tmp1$mld, tmp2$mld)
+  expect_equal(tmp1$decile10, tmp2$decile10)
+
+  # Interpolation (one year)
+  tmp1 <- pip("AGO", year = 2004, fill_gaps = TRUE, lkup = lkups)
+  expect_equal(tmp1$gini, NA_real_)
+  expect_equal(tmp2$median ,NA_real_)
+  expect_equal(tmp1$mld, NA_real_)
+  expect_equal(tmp1$decile10, NA_real_)
+
+  # Extrapolation (multiple years)
+  tmp1 <- pip("AGO", year = 1981:1999, fill_gaps = TRUE, lkup = lkups)
+  expect_equal(unique(tmp1$gini), tmp2$gini)
+  expect_equal(unique(tmp2$median), tmp2$median)
+  expect_equal(unique(tmp1$mld), tmp2$mld)
+  expect_equal(unique(tmp1$decile10), tmp2$decile10)
+
+  # Interpolation (mulitiple year)
+  tmp1 <- pip("AGO", year = 2001:2007, fill_gaps = TRUE, lkup = lkups)
+  expect_equal(unique(tmp1$gini), NA_real_)
+  expect_equal(unique(tmp2$median), NA_real_)
+  expect_equal(unique(tmp1$mld), NA_real_)
+  expect_equal(unique(tmp1$decile10), NA_real_)
+
+})
+
 # Check regional aggregations ----
 
 test_that("Regional aggregations are working", {

--- a/tests/testthat/test-pip-local.R
+++ b/tests/testthat/test-pip-local.R
@@ -36,7 +36,7 @@ test_that("Reporting level filtering is working", {
 
   expect_equal(nrow(tmp$all), 3)
   expect_equal(sort(tmp$all$reporting_level), c("national", "rural", "urban"))
-  })
+})
 
 # Use only test data
 # lkups$svy_lkup <- lkups$svy_lkup[(cache_id %in% files | country_code == "AGO")]
@@ -277,28 +277,28 @@ test_that("Distributional stats are correct for interpolated/extrapolated report
   tmp1 <- pip("AGO", year = 1981, fill_gaps = TRUE, lkup = lkups)
   tmp2 <- pip("AGO", year = 2000, fill_gaps = FALSE, lkup = lkups)
   expect_equal(tmp1$gini, tmp2$gini)
-  expect_equal(tmp2$median, tmp2$median)
+  expect_equal(tmp1$median, tmp2$median)
   expect_equal(tmp1$mld, tmp2$mld)
   expect_equal(tmp1$decile10, tmp2$decile10)
 
   # Interpolation (one year)
   tmp1 <- pip("AGO", year = 2004, fill_gaps = TRUE, lkup = lkups)
   expect_equal(tmp1$gini, NA_real_)
-  expect_equal(tmp2$median ,NA_real_)
+  expect_equal(tmp1$median ,NA_real_)
   expect_equal(tmp1$mld, NA_real_)
   expect_equal(tmp1$decile10, NA_real_)
 
   # Extrapolation (multiple years)
   tmp1 <- pip("AGO", year = 1981:1999, fill_gaps = TRUE, lkup = lkups)
   expect_equal(unique(tmp1$gini), tmp2$gini)
-  expect_equal(unique(tmp2$median), tmp2$median)
+  expect_equal(unique(tmp1$median), tmp2$median)
   expect_equal(unique(tmp1$mld), tmp2$mld)
   expect_equal(unique(tmp1$decile10), tmp2$decile10)
 
   # Interpolation (mulitiple year)
   tmp1 <- pip("AGO", year = 2001:2007, fill_gaps = TRUE, lkup = lkups)
   expect_equal(unique(tmp1$gini), NA_real_)
-  expect_equal(unique(tmp2$median), NA_real_)
+  expect_equal(unique(tmp1$median), NA_real_)
   expect_equal(unique(tmp1$mld), NA_real_)
   expect_equal(unique(tmp1$decile10), NA_real_)
 

--- a/tests/testthat/test-pip.R
+++ b/tests/testthat/test-pip.R
@@ -261,6 +261,40 @@ test_that("imputation is working for extrapolated aggregate distribution", {
   # expect_equal(tmp$mean[tmp$reporting_level == "national"], 62.5904793524725 * 12 / 365)
 })
 
+test_that("Distributional stats are correct for interpolated/extrapolated reporting years",{
+
+  # Extrapolation (one year)
+  tmp1 <- pip("AGO", year = 1981, fill_gaps = TRUE, lkup = lkups)
+  tmp2 <- pip("AGO", year = 2000, fill_gaps = FALSE, lkup = lkups)
+  expect_equal(tmp1$gini, tmp2$gini)
+  expect_equal(tmp1$median, tmp2$median)
+  expect_equal(tmp1$mld, tmp2$mld)
+  expect_equal(tmp1$decile10, tmp2$decile10)
+
+  # Interpolation (one year)
+  tmp1 <- pip("AGO", year = 2004, fill_gaps = TRUE, lkup = lkups)
+  expect_equal(tmp1$gini, NA_real_)
+  expect_equal(tmp1$median ,NA_real_)
+  expect_equal(tmp1$mld, NA_real_)
+  expect_equal(tmp1$decile10, NA_real_)
+
+  # Extrapolation (multiple years)
+  tmp1 <- pip("AGO", year = 1981:1999, fill_gaps = TRUE, lkup = lkups)
+  expect_equal(unique(tmp1$gini), tmp2$gini)
+  expect_equal(unique(tmp1$median), tmp2$median)
+  expect_equal(unique(tmp1$mld), tmp2$mld)
+  expect_equal(unique(tmp1$decile10), tmp2$decile10)
+
+  # Interpolation (mulitiple year)
+  tmp1 <- pip("AGO", year = 2001:2007, fill_gaps = TRUE, lkup = lkups)
+  expect_equal(unique(tmp1$gini), NA_real_)
+  expect_equal(unique(tmp1$median), NA_real_)
+  expect_equal(unique(tmp1$mld), NA_real_)
+  expect_equal(unique(tmp1$decile10), NA_real_)
+
+})
+
+
 # Check regional aggregations ----
 test_that("Regional aggregations are working", {
   tmp <- pip(

--- a/tests/testthat/test-utils-plumber.R
+++ b/tests/testthat/test-utils-plumber.R
@@ -99,7 +99,7 @@ test_that("check_parameters() works as expected", {
   req <- list(argsQuery = list(povline = "all"))
   tmp <- check_parameters(req, lkups$query_controls)
   expect_false(tmp)
-  req <- list(argsQuery = list(povline = 200))
+  req <- list(argsQuery = list(povline = 20000))
   tmp <- check_parameters(req, lkups$query_controls)
   expect_false(tmp)
 


### PR DESCRIPTION
Hi @tonyfujs 

I looked into this issue originally raised by @danielmahler.

>  Why are the missing value patterns for gini and median different?  I think it should follow the same missing value pattern as the Gini

I think this was caused by how merging between the output of `fg_pip()` was conducted. Using `country_code`, `reporting_year` etc. doesn't work because these are not linked to observations in the dist stat table. For extrapolated values we would like to match e.g AGO 1981 (ref year) with AGO 2000 (survey year) but using the  `reporting_year` for this merge (obviously)  doesn't work. However using the `cache_id` will since the cache_id used for extrapolation (AGO_2000_xxx) is the same as the corresponding survey / cache_id in the dist stat table. 

To get a better sense of the issue try: 

```r
u <- "https://api.worldbank.org/pip/v1/pip?country=all&year=all&povline=1.9&fill_gaps=TRUE"
df <- jsonlite::fromJSON(u)
df <- df[(is.na(df$gini) | is.na(df$median)),]
df <- df[!(is.na(df$gini) & is.na(df$median)),]
df[c('gini', 'median')]

pip("AGO", year = 1981, fill_gaps = TRUE, lkup = lkups$versions_paths$latest_release)
pip("AGO", year = 2001, fill_gaps = TRUE, lkup = lkups$versions_paths$latest_release)
pip("AGO", year = "all",  fill_gaps = TRUE, lkup = lkups)
``` 

Let me know if you have questions. 