### PR TITLE
Add guidelines and templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Something is wrong with pipapi. 
+title: ''
+labels: 'type: bug'
+assignees: ''
+---
+
+## Describition
+
+A clear and concise description of what the bug is.
+## Reproducible example
+
+* [ ] Post a [minimal reproducible example](https://www.tidyverse.org/help/) so the maintainer can troubleshoot the problems you identify. A reproducible example is:
+    * [ ] **Runnable**: post enough R code and data so any onlooker can create the error on their own computer.
+    * [ ] **Minimal**: reduce runtime wherever possible and remove complicated details that are irrelevant to the issue at hand.
+    * [ ] **Readable**: format your code according to the [tidyverse style guide](https://style.tidyverse.org/).
+
+## Expected behavior
+
+A clear and concise description of what you expected to happen.
+
+## Diagnostic information
+
+* A [reproducible example](https://github.com/tidyverse/reprex).
+* Session info, available through `sessionInfo()` or [`reprex(si = TRUE)`](https://github.com/tidyverse/reprex).
+* A stack trace from `traceback()` or `rlang::trace_back()`.
+* The version of `{pipapi}` currently installed. `packageDescription("pipapi")$Version` shows you this.
+
+## Additional context
+
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: 'type: enhancement'
+assignees: ''
+
+---
+
+## Prework
+
+* [ ] If there is [already a relevant issue](https://github.com/PIP-Technical-Team/pipapi/issues), whether open or closed, comment on the existing thread instead of posting a new issue.
+* [ ] New features take time and effort to create, and they take even more effort to maintain. So if the purpose of the feature is to resolve a struggle you are encountering personally, please consider first posting a "question" or "other" issue so we can discuss your use case and search for existing solutions first.
+* [ ] Format your code according to the [tidyverse style guide](https://style.tidyverse.org/).
+
+## Proposal
+
+If applicable, write a minimal example in R code or pseudo-code to show input, usage, and desired output.
+
+To help us read any code you include (optional) please try to follow the [tidyverse style guide](https://style.tidyverse.org/). The `style_text()` and `style_file()` functions from the [`styler`](https://github.com/r-lib/styler) package make it easier.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+# Prework
+
+* [ ] I understand and agree to the [contributing guidelines](https://github.com/PIP-Technical-Team/pipapi/blob/master/CONTRIBUTING.md).
+* [ ] I have already submitted an [issue](https://github.com/PIP-Technical-Team/pipapi/issues) to discuss my idea with the maintainer.
+
+# Related GitHub issues and pull requests
+
+* Ref: #
+
+# Summary
+
+Please explain the purpose and scope of your contribution.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing
+
+Development is a community effort, and we welcome participation.
+
+## Issues
+
+* Before posting a new issue or discussion topic, please take a moment to search for existing similar threads in order to avoid duplication.
+* For bug reports: if you can, please install the latest GitHub version of `pipapi` (i.e. `remotes::install_github("PIP-Technical-Team/pipapi")`) and verify that the issue still persists.
+* Describe your issue in prose as clearly and concisely as possible.
+* For any problem you identify, post a [minimal reproducible example](https://www.tidyverse.org/help/) so the maintainer can troubleshoot. A reproducible example is:
+    * **Runnable**: post enough R code and data so any onlooker can create the error on their own computer.
+    * **Minimal**: reduce runtime wherever possible and remove complicated details that are irrelevant to the issue at hand.
+    * **Readable**: format your code according to the [tidyverse style guide](https://style.tidyverse.org/).
+
+## Development
+
+External code contributions are extremely helpful in the right circumstances. Here are the recommended steps.
+
+1. Prior to contribution, please propose your idea in a discussion topic or issue thread so you and the maintainer can define the intent and scope of your work.
+2. [Clone](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository-from-github/cloning-a-repository) or [fork](https://help.github.com/articles/fork-a-repo/) the repository.
+3. Follow the [GitHub flow](https://guides.github.com/introduction/flow/index.html) to create a new branch, add commits, and open a pull request.
+4. Discuss your code with the maintainer in the pull request thread.
+5. If everything looks good, the maintainer will merge your code into the project.
+
+Please also follow these additional guidelines.
+
+* Respect the architecture and reasoning of the package.
+* If possible, keep contributions small enough to easily review manually. It is okay to split up your work into multiple pull requests.
+* For new features or functionality, add tests in `tests`. Tests that can be automated should go in `tests/testthat/`.
+* Format your code according to the [tidyverse style guide](https://style.tidyverse.org/) and check your formatting with the `lint_package()` function from the [`lintr`](https://github.com/jimhester/lintr) package.
+* Check code coverage with `covr::package_coverage()`. Automated tests should cover all the new or changed functionality in your pull request.
+* Run overall package checks with `devtools::check()`.


### PR DESCRIPTION
Hi @tonyfujs 

I think this could be useful to add before the launch. Includes: 

* A contributing guideline
* Issues templates for bug reports and feature requests 
* PR template   

