### PR TITLE
include unit tests for fg_remove_duplicates and sub functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,8 +9,8 @@
 return all countries pertaining to the specified region
 - the `/valid-params` endpoint gains an `endpoint` parameter that allows to only
 return parameters that are relevant to the specified endpoint
-- [New /valid-years endpoint returns available years for both survey and 
-interpolated years](https://github.com/PIP-Technical-Team/pipapi/issues/182)
+- [Add /valid_years as new endpoint to get the valid years information of the data](https://github.com/PIP-Technical-Team/pipapi/issues/182)
+- [Add unit tests for newly created fg_remove_duplicates() and sub-functions](https://github.com/PIP-Technical-Team/pipapi/issues/226)
 
 # pipapi 1.0.0
 

--- a/tests/testthat/test-fg_pip-local.R
+++ b/tests/testthat/test-fg_pip-local.R
@@ -96,3 +96,39 @@ test_that("Imputation is working for interpolated aggregate distribution", {
 
   expect_equal(nrow(tmp), 2)
 })
+
+
+test_that("Check classes of function fg_assign_nas_values_to_dup_cols", {
+  tmp <- data.table::data.table(a = rnorm(5), b = letters[1:5], c = 1:5, d = rnorm(5))
+  tmp <- fg_assign_nas_values_to_dup_cols(df, c('a', 'b', 'c'))
+
+  expect_type(tmp$a, "double")
+  expect_type(tmp$b, "character")
+  expect_type(tmp$c, "integer")
+})
+
+
+test_that("Test fg_standardize_cache_id", {
+  x <- c("CHN_1981_CRHS-CUHS_D2_INC_GROUP", "CHN_1981_CRHS-CUHS_D2_INC_GROUP",
+         "CHN_1981_CRHS-CUHS_D2_INC_GROUP", "CHN_1981_CRHS-CUHS_D2_INC_GROUP",
+         "CHN_1981_CRHS-CUHS_D2_INC_GROUP", "CHN_1981_CRHS-CUHS_D2_INC_GROUP")
+  y <- fg_standardize_cache_id(x, x, '')
+
+  expect_length(y, length(x))
+  expect_identical(x, y)
+})
+
+
+test_that("fg_remove_duplicates test", {
+  df <- data.table::data.table(cache_id = c("CHN_1981_CRHS-CUHS_D2_INC_GROUP", "CHN_1981_CRHS-CUHS_D2_INC_GROUP",
+                                            "CHN_1981_CRHS-CUHS_D2_INC_GROUP", "CHN_1981_CRHS-CUHS_D2_INC_GROUP",
+                                            "CHN_1981_CRHS-CUHS_D2_INC_GROUP", "CHN_1981_CRHS-CUHS_D2_INC_GROUP"),
+                               data_interpolation_id = c("CHN_1981_CRHS-CUHS_D2_INC_GROUP_rural", "CHN_1981_CRHS-CUHS_D2_INC_GROUP_rural",
+                                                         "CHN_1981_CRHS-CUHS_D2_INC_GROUP_rural", "CHN_1981_CRHS-CUHS_D2_INC_GROUP_urban",
+                                                         "CHN_1981_CRHS-CUHS_D2_INC_GROUP_urban", "CHN_1981_CRHS-CUHS_D2_INC_GROUP_urban"),
+                               reporting_level = c("rural", "rural", "rural", "urban", "urban", "urban"))
+
+  res <- fg_remove_duplicates(df, c('data_interpolation_id'))
+  expect_equal(nrow(res), 2)
+  expect_type(tmp$data_interpolation_id, "character")
+})


### PR DESCRIPTION
Unit tests for functions `fg_remove_duplicates`, `fg_standardize_cache_id` and `fg_assign_nas_values_to_dup_cols`. 