### PR TITLE
optimise pip call 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 - [Sort the rows by `country_code` and `reporting_year` in the pip response.](https://github.com/PIP-Technical-Team/pipapi/issues/248)
 - [Fix casing making pip call case insensitive](https://github.com/PIP-Technical-Team/pipapi/issues/120)
 - [Add unit tests for newly created fg_remove_duplicates() and sub-functions](https://github.com/PIP-Technical-Team/pipapi/issues/226)
+- [Add unit tests for newly created fg_remove_duplicates() and sub-functions](https://github.com/PIP-Technical-Team/pipapi/issues/226)
 
 ## New features
 - Region codes can now be passed directly to the `country` query parameter to 
@@ -12,7 +13,7 @@ return all countries pertaining to the specified region
 return parameters that are relevant to the specified endpoint
 - [Add /valid_years endpoint that returns available years for both survey and 
 interpolated years](https://github.com/PIP-Technical-Team/pipapi/issues/182)
-- [Add unit tests for newly created fg_remove_duplicates() and sub-functions](https://github.com/PIP-Technical-Team/pipapi/issues/226)
+
 
 # pipapi 1.0.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,7 +14,6 @@ return parameters that are relevant to the specified endpoint
 - [Add /valid_years endpoint that returns available years for both survey and 
 interpolated years](https://github.com/PIP-Technical-Team/pipapi/issues/182)
 
-
 # pipapi 1.0.0
 
 ## New features

--- a/R/add_agg_stats.R
+++ b/R/add_agg_stats.R
@@ -6,7 +6,7 @@
 add_agg_stats <- function(df) {
   # Keep only Urban / Rural observations that will be aggregated at the
   # national level
-  aggregated <- df[df$is_used_for_aggregation == TRUE, ]
+  aggregated <- df[df$is_used_for_aggregation, ]
 
   if (nrow(aggregated) > 0) {
     aggregated_list <- split(aggregated,

--- a/R/fg_pip.R
+++ b/R/fg_pip.R
@@ -43,7 +43,6 @@ fg_pip <- function(country,
 
   #NEW: iterate over survey files
   for (svy_id in seq_along(unique_survey_files)) {
-
     # Extract country-years for which stats will be computed from the same files
     # tmp_metadata <- interpolation_list[[unique_survey_files[svy_id]]]$tmp_metadata
     svy_data <- get_svy_data(interpolation_list[[unique_survey_files[svy_id]]]$cache_ids,
@@ -163,7 +162,8 @@ fg_remove_duplicates <- function(df,
 fg_standardize_cache_id <- function(cache_id,
                                     interpolation_id,
                                     reporting_level) {
-  out <- ifelse(grepl("[|]", interpolation_id),
+
+  out <- ifelse(grepl("|", interpolation_id, fixed = TRUE),
                 gsub(paste0("_",
                             unique(reporting_level),
                             collapse = '|'),
@@ -181,20 +181,7 @@ fg_standardize_cache_id <- function(cache_id,
 
 fg_assign_nas_values_to_dup_cols <- function(df,
                                              cols) {
-  cols_class <- unlist(lapply(df[, ..cols], typeof))
-  vars_to_collapse_char <- names(cols_class[cols_class == "character"])
-  vars_to_collapse_int <- names(cols_class[cols_class == "integer"])
-  vars_to_collapse_real <- names(cols_class[cols_class == "double"])
-
-  if (length(vars_to_collapse_char) > 0) {
-    df[, vars_to_collapse_char] <- NA_character_
-  }
-  if (length(vars_to_collapse_int) > 0) {
-    df[, vars_to_collapse_int]  <- NA_integer_
-  }
-  if (length(vars_to_collapse_real) > 0) {
-    df[, vars_to_collapse_real] <- NA_real_
-  }
-
+  #Classes are maintained by default.
+  df[, (cols) := NA]
   return(df)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -34,9 +34,10 @@ subset_lkup <- function(country,
                         reporting_level,
                         lkup,
                         valid_regions) {
-  svy_n <- nrow(lkup)
-  keep <- rep(TRUE, svy_n)
-  # browser()
+
+
+
+  keep <- TRUE
   # Select data files based on requested country, year, etc.
   # Select countries
   if (country[1] != "all") {
@@ -96,8 +97,7 @@ select_reporting_level <- function(lkup,
 
   } else if (reporting_level == "national") {
     # Subnational levels necessary to compute national stats for aggregate distributions
-    keep <- keep & (lkup$reporting_level == reporting_level |
-                      lkup$is_used_for_aggregation == TRUE)
+    keep <- keep & (lkup$reporting_level == reporting_level | lkup$is_used_for_aggregation)
     return(keep)
 
   } else {
@@ -435,8 +435,8 @@ subset_ctry_years <- function(country,
                               year,
                               lkup,
                               valid_regions) {
-  svy_n <- nrow(lkup)
-  keep <- rep(TRUE, svy_n)
+
+  keep <- TRUE
   # Select data files based on requested country, year, etc.
   # Select countries
   if (!all(country %in% c("all", valid_regions))) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -35,8 +35,6 @@ subset_lkup <- function(country,
                         lkup,
                         valid_regions) {
 
-
-
   keep <- TRUE
   # Select data files based on requested country, year, etc.
   # Select countries

--- a/inst/plumber/v1/endpoints.R
+++ b/inst/plumber/v1/endpoints.R
@@ -542,7 +542,7 @@ function(req) {
 #* Return valid years
 #* @get /api/v1/valid-years
 #* @param version:[chr] Data version. Defaults to most recent version. See api/v1/versions
-#* @serializer json list(na="null")
+#* @serializer switch
 function(req) {
   params <- req$argsQuery
   params$lkup <- lkups$versions_paths[[params$version]]

--- a/inst/plumber/v1/openapi.yaml
+++ b/inst/plumber/v1/openapi.yaml
@@ -235,4 +235,3 @@ paths:
         default:
           description: Default response.
       parameters: []
-

--- a/man/get_param_values.Rd
+++ b/man/get_param_values.Rd
@@ -3,16 +3,22 @@
 \name{get_param_values}
 \alias{get_param_values}
 \title{Get valid query parameter values
-Get vector of accepted query parameter values}
+Get vector of accepted query parameter values for the API}
 \usage{
-get_param_values(lkup, version)
+get_param_values(
+  lkup,
+  version,
+  endpoint = c("all", "aux", "pip", "pip-grp", "pip-info", "valid-params")
+)
 }
 \arguments{
 \item{lkup}{list: A list of lkup tables}
 
 \item{version}{character: Data version. Defaults to most recent version.}
+
+\item{endpoint}{character: the endpoint for which to return valid parameters}
 }
 \description{
 Get valid query parameter values
-Get vector of accepted query parameter values
+Get vector of accepted query parameter values for the API
 }

--- a/tests/testthat/test-fg_pip-local.R
+++ b/tests/testthat/test-fg_pip-local.R
@@ -99,7 +99,7 @@ test_that("Imputation is working for interpolated aggregate distribution", {
 
 
 test_that("Check classes of function fg_assign_nas_values_to_dup_cols", {
-  tmp <- data.table::data.table(a = rnorm(5), b = letters[1:5], c = 1:5, d = rnorm(5))
+  df <- data.table::data.table(a = rnorm(5), b = letters[1:5], c = 1:5, d = rnorm(5))
   tmp <- fg_assign_nas_values_to_dup_cols(df, c('a', 'b', 'c'))
 
   expect_type(tmp$a, "double")
@@ -130,5 +130,5 @@ test_that("fg_remove_duplicates test", {
 
   res <- fg_remove_duplicates(df, c('data_interpolation_id'))
   expect_equal(nrow(res), 2)
-  expect_type(tmp$data_interpolation_id, "character")
+  expect_type(res$data_interpolation_id, "character")
 })

--- a/tests/testthat/test-utils-plumber.R
+++ b/tests/testthat/test-utils-plumber.R
@@ -131,7 +131,7 @@ test_that("check_parameters() works as expected", {
   # Invalid reporting_level parameter
   req <- list(argsQuery = list(reporting_level = "ALL"))
   tmp <- check_parameters(req, lkups$query_controls)
-  expect_false(tmp)
+  expect_true(tmp)
 
   # Invalid ppp parameter
   req <- list(argsQuery = list(ppp = "NULL"))


### PR DESCRIPTION
- removed `==` comparison with logical values like `== TRUE`, `== FALSE` etc 
- For exact matching used `fixed = TRUE` instead of regex matching in `grepl` which is faster
- optimised and reduced `fg_assign_nas_values_to_dup_cols` function
- Updated openapi.yaml to include `valid-years` api from https://github.com/PIP-Technical-Team/pipapi/issues/182 