### PR TITLE
rewrite parse parameter

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,8 @@ Suggests:
     httr,
     jsonlite,
     future.callr,
-    future.apply
+    future.apply, 
+    methods
 Language: en-US
 Imports: 
     data.table,

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@ return all countries pertaining to the specified region
 return parameters that are relevant to the specified endpoint
 - New `/valid-years` endpoint returns available years for both survey and 
 interpolated years
-- [Create global varibales for query parameter.](https://github.com/PIP-Technical-Team/pipapi/issues/241)
+- [auto convert parameters to their respective types in `parse_parameters`](https://github.com/PIP-Technical-Team/pipapi/issues/241)
 
 ## New features
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@ return all countries pertaining to the specified region
 return parameters that are relevant to the specified endpoint
 - New `/valid-years` endpoint returns available years for both survey and 
 interpolated years
+- [Create global varibales for query parameter.](https://github.com/PIP-Technical-Team/pipapi/issues/241)
 
 ## New features
 

--- a/R/get_param_values.R
+++ b/R/get_param_values.R
@@ -49,7 +49,7 @@ get_param_values <- function(lkup,
   if (endpoint != "all") {
     # Only return the parameters for a specific endpoint
     endpoint <- endpoint_map[endpoint]
-    out <- out[names(out) %in% formalArgs(endpoint)]
+    out <- out[names(out) %in% methods::formalArgs(endpoint)]
     # Handle the exception for pip-grp (takes regional codes instead of country codes)
     # Bad API design here. Needs review
     if (endpoint == "pip_grp") {

--- a/R/get_pip_version.R
+++ b/R/get_pip_version.R
@@ -1,6 +1,6 @@
 #' Return the versions of the pip packages used for computations
 #'
-#' @param pip_packages character: Custom packages powering the API
+#' @param pip_package character: Custom packages powering the API
 #' @inheritParams pip
 #' @return list
 #' @export

--- a/R/utils-plumber.R
+++ b/R/utils-plumber.R
@@ -1,7 +1,3 @@
-globals <- list(char_values = c("country", "year", "group_by", "welfare_type","reporting_level", "format", "parameter", "endpoint"),
-                num_values = c("povline", "popshare", "ppp"),
-                logical_values = c("fill_gaps", "aggregate"))
-
 #' Check validity of query parameters
 #'
 #' @param req req: plumber request environment
@@ -121,34 +117,9 @@ validate_query_parameters <-
 #' @return character
 #' @noRd
 parse_parameters <- function(params) {
-  for (i in seq_along(params)) {
-    params[[i]] <- parse_parameter(
-      param = params[[i]],
-      param_name = names(params)[i]
-    )
-  }
+  params <- type.convert(params, as.is = TRUE)
+
   return(params)
-}
-
-#' Parse parameters
-#' @param param character: Query parameter to be parsed
-#' @param param_name character: Parameter name
-#' @return character
-#' @noRd
-parse_parameter <- function(param, param_name) {
-  param <- urltools::url_decode(param)
-  param <- strsplit(param, ",")
-  param <- unlist(param)
-
-  if (param_name %in% globals$char_values) {
-    param <- as.character(param)
-  } else if (param_name %in% globals$num_values) {
-    param <- as.numeric(param)
-  } else if (param_name %in% globals$logical_values) {
-    param <- as.logical(param)
-  }
-
-  return(param)
 }
 
 #' Switch serializer

--- a/R/utils-plumber.R
+++ b/R/utils-plumber.R
@@ -1,3 +1,7 @@
+globals <- list(char_values = c("country", "year", "group_by", "welfare_type","reporting_level", "format", "parameter", "endpoint"),
+                num_values = c("povline", "popshare", "ppp"),
+                logical_values = c("fill_gaps", "aggregate"))
+
 #' Check validity of query parameters
 #'
 #' @param req req: plumber request environment
@@ -136,13 +140,11 @@ parse_parameter <- function(param, param_name) {
   param <- strsplit(param, ",")
   param <- unlist(param)
 
-  # CREATE GLOBALS TO AVOID HARD CODED VALUES HERE
-  if (param_name %in% c("country", "year", "group_by", "welfare_type",
-                        "reporting_level", "format", "parameter", "endpoint")) {
+  if (param_name %in% globals$char_values) {
     param <- as.character(param)
-  } else if (param_name %in% c("povline", "popshare", "ppp")) {
+  } else if (param_name %in% globals$num_values) {
     param <- as.numeric(param)
-  } else if (param_name %in% c("fill_gaps", "aggregate")) {
+  } else if (param_name %in% globals$logical_values) {
     param <- as.logical(param)
   }
 

--- a/man/get_param_values.Rd
+++ b/man/get_param_values.Rd
@@ -3,16 +3,22 @@
 \name{get_param_values}
 \alias{get_param_values}
 \title{Get valid query parameter values
-Get vector of accepted query parameter values}
+Get vector of accepted query parameter values for the API}
 \usage{
-get_param_values(lkup, version)
+get_param_values(
+  lkup,
+  version,
+  endpoint = c("all", "aux", "pip", "pip-grp", "pip-info", "valid-params")
+)
 }
 \arguments{
 \item{lkup}{list: A list of lkup tables}
 
 \item{version}{character: Data version. Defaults to most recent version.}
+
+\item{endpoint}{character: the endpoint for which to return valid parameters}
 }
 \description{
 Get valid query parameter values
-Get vector of accepted query parameter values
+Get vector of accepted query parameter values for the API
 }

--- a/man/get_pip_version.Rd
+++ b/man/get_pip_version.Rd
@@ -7,9 +7,9 @@
 get_pip_version(pip_package = c("pipapi"), lkup)
 }
 \arguments{
-\item{lkup}{list: A list of lkup tables}
+\item{pip_package}{character: Custom packages powering the API}
 
-\item{pip_packages}{character: Custom packages powering the API}
+\item{lkup}{list: A list of lkup tables}
 }
 \value{
 list

--- a/tests/testthat/test-utils-plumber.R
+++ b/tests/testthat/test-utils-plumber.R
@@ -52,7 +52,7 @@ test_that("parse_parameters() works as expected", {
   )
   tmp <- parse_parameters(params)
   expect_type(tmp$country, "character")
-  expect_type(tmp$year, "character")
+  expect_type(tmp$year, "integer")
   expect_true(is.numeric(tmp$povline))
   expect_type(tmp$fill_gaps, "logical")
   expect_type(tmp$aggregate, "logical")


### PR DESCRIPTION
Used `type.convert` to auto change parameters to their respective types. This means that moving forward `year` is expected to be of type integer instead of character. Have tested this and it works. Did the corresponding change in tests as well. 