### PR TITLE
sanitise inputs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,9 +10,15 @@
 return all countries pertaining to the specified region
 - the `/valid-params` endpoint gains an `endpoint` parameter that allows to only
 return parameters that are relevant to the specified endpoint
-- [Add /valid_years endpoint that returns available years for both survey and 
+- [Add /valid-years endpoint that returns available years for both survey and 
 interpolated years](https://github.com/PIP-Technical-Team/pipapi/issues/182)
 - [Add unit tests for newly created fg_remove_duplicates() and sub-functions](https://github.com/PIP-Technical-Team/pipapi/issues/226)
+- [Sanitize user inputs in get_aux_table](https://github.com/PIP-Technical-Team/pipapi/issues/259)
+
+## New features
+
+- [Add /valid_years as new endpoint to get the valid years information of the data](https://github.com/PIP-Technical-Team/pipapi/issues/182)
+>>>>>>> c4d8f8f (sanitize inputs)
 
 # pipapi 1.0.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@ return all countries pertaining to the specified region
 return parameters that are relevant to the specified endpoint
 - New `/valid-years` endpoint returns available years for both survey and 
 interpolated years
+- [Sanitize user inputs in get_aux_table](https://github.com/PIP-Technical-Team/pipapi/issues/259)
 
 ## New features
 

--- a/R/get_aux_table.R
+++ b/R/get_aux_table.R
@@ -7,10 +7,13 @@
 #' @export
 #'
 get_aux_table <- function(data_dir, table) {
+  # Strip all "non-word" characters from user input
+  sanitize_table_name <- gsub("\\W", "", table)
+
   out <- fst::read_fst(sprintf(
     "%s/_aux/%s.fst",
     data_dir,
-    table
+    sanitize_table_name
   ))
 
   return(out)

--- a/tests/testthat/test-get_aux_table.R
+++ b/tests/testthat/test-get_aux_table.R
@@ -10,3 +10,8 @@ test_that("get_aux_table() works", {
   })
   expect_equal(length(dl), length(tables))
 })
+
+test_that("get_aux_table() returns an error", {
+  expect_error(pipapi::get_aux_table(data_folder_root, "../survey_data/ARG_1980_EPH_D2_INC_GROUP.fst"),
+               "Error opening fst file for reading, please check access rights and file availability")
+})


### PR DESCRIPTION
Although, I cannot find a way to exploit the current implementation of `get_aux_table` but I think it would be good to follow the best practice when passing file names as input to the function. 

Closes #259 