### PR TITLE
better error message when passing more than one dataset

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,6 @@ Suggests:
     rmarkdown,
     markdown,
     assertthat,
-    purrr,
     callr,
     httr,
     jsonlite,

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 - [Add unit tests for newly created fg_remove_duplicates() and sub-functions](https://github.com/PIP-Technical-Team/pipapi/issues/226)
 - [auto convert parameters to their respective types in `parse_parameters`](https://github.com/PIP-Technical-Team/pipapi/issues/241)
 - [Sanitize user inputs in get_aux_table](https://github.com/PIP-Technical-Team/pipapi/issues/259)
+- Removed `purrr` dependency
 
 ## New features
 - Region codes can now be passed directly to the `country` query parameter to 

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 - [auto convert parameters to their respective types in `parse_parameters`](https://github.com/PIP-Technical-Team/pipapi/issues/241)
 - [Sanitize user inputs in get_aux_table](https://github.com/PIP-Technical-Team/pipapi/issues/259)
 - Removed `purrr` dependency
+- [Better error message when passing more than one dataset as `lkup` in `pip` call](https://github.com/PIP-Technical-Team/pipapi/issues/263)
 
 ## New features
 - Region codes can now be passed directly to the `country` query parameter to 

--- a/R/create_lkups.R
+++ b/R/create_lkups.R
@@ -16,7 +16,7 @@ create_versioned_lkups <-
     versions <- names(data_dirs)
     # versions[1] <- "latest_release"
 
-    versions_paths <- purrr::map(data_dirs, create_lkups, versions = versions)
+    versions_paths <- lapply(data_dirs, create_lkups, versions = versions)
     names(versions_paths) <- versions
 
     return(list(versions = versions,

--- a/R/pip.R
+++ b/R/pip.R
@@ -75,6 +75,7 @@ pip <- function(country = "all",
   Try passing a single one by subsetting it lkup <- lkups$versions_paths$dataset_name_PROD")
 
   # Make country case insensitive
+
   country <- tolower(country)
   country <- if (country == "all") country else toupper(country)
   # Make year case insensitive as well. Allow all, ALL, All etc.

--- a/R/pip.R
+++ b/R/pip.R
@@ -68,14 +68,16 @@ pip <- function(country = "all",
   welfare_type <- match.arg(welfare_type)
   reporting_level <- match.arg(reporting_level)
   group_by <- match.arg(group_by)
+
   # If svy_lkup and ref_lkup are not part of lkup throw an error.
   if (!all(c('svy_lkup', 'ref_lkup') %in% names(lkup)))
     stop("You are probably passing more than one dataset as lkup argument.
   Try passing a single one by subsetting it lkup <- lkups$versions_paths$dataset_name_PROD")
-  #Make country case insensitive
+
+  # Make country case insensitive
   country <- tolower(country)
   country <- if (country == "all") country else toupper(country)
-  #Make year case insensitive as well. Allow all, ALL, All etc.
+  # Make year case insensitive as well. Allow all, ALL, All etc.
   year <- tolower(year)
   # **** TO BE REMOVED **** REMOVAL STARTS HERE
   # Once `pip-grp` has been integrated in ingestion pipeline

--- a/R/pip.R
+++ b/R/pip.R
@@ -68,9 +68,13 @@ pip <- function(country = "all",
   welfare_type <- match.arg(welfare_type)
   reporting_level <- match.arg(reporting_level)
   group_by <- match.arg(group_by)
+  # If svy_lkup and ref_lkup are not part of lkup throw an error.
+  if (!all(c('svy_lkup', 'ref_lkup') %in% names(lkup)))
+    stop("You are probably passing more than one dataset as lkup argument.
+  Try passing a single one by subsetting it lkup <- lkups$versions_paths$dataset_name_PROD")
   #Make country case insensitive
   country <- tolower(country)
-  country <- if(country == "all") country else toupper(country)
+  country <- if (country == "all") country else toupper(country)
   #Make year case insensitive as well. Allow all, ALL, All etc.
   year <- tolower(year)
   # **** TO BE REMOVED **** REMOVAL STARTS HERE

--- a/R/ui_functions.R
+++ b/R/ui_functions.R
@@ -289,6 +289,9 @@ ui_cp_charts <- function(country = "AGO",
                          povline = 1.9,
                          pop_units = 1e6,
                          lkup) {
+  # Only supports single country selection
+  # Make it explicit
+  country <- country[1]
 
   # Select surveys to use for CP page
   lkup$svy_lkup <- lkup$svy_lkup[display_cp == 1]

--- a/man/get_pip_version.Rd
+++ b/man/get_pip_version.Rd
@@ -7,9 +7,9 @@
 get_pip_version(pip_package = c("pipapi"), lkup)
 }
 \arguments{
-\item{lkup}{list: A list of lkup tables}
+\item{pip_package}{character: Custom packages powering the API}
 
-\item{pip_packages}{character: Custom packages powering the API}
+\item{lkup}{list: A list of lkup tables}
 }
 \value{
 list

--- a/tests/testthat/test-get_aux_table.R
+++ b/tests/testthat/test-get_aux_table.R
@@ -1,6 +1,6 @@
 skip_if(Sys.getenv("PIPAPI_DATA_ROOT_FOLDER") == "")
 lkups <- create_versioned_lkups(Sys.getenv("PIPAPI_DATA_ROOT_FOLDER"))
-data_folder_root <-lkups$versions_paths[[lkups$latest_release]]$data_root
+data_folder_root <- lkups$versions_paths[[lkups$latest_release]]$data_root
 
 tables <- c("gdp", "pce", "pop", "cpi", "ppp")
 
@@ -14,4 +14,4 @@ test_that("get_aux_table() works", {
 test_that("get_aux_table() returns an error", {
   expect_error(pipapi::get_aux_table(data_folder_root, "../survey_data/ARG_1980_EPH_D2_INC_GROUP.fst"),
                "Error opening fst file for reading, please check access rights and file availability")
-}
+})

--- a/tests/testthat/test-pip.R
+++ b/tests/testthat/test-pip.R
@@ -6,7 +6,7 @@ skip("Disable until a full set of anonymous package data has been created")
 
 # files <- sub("[.]fst", "", list.files("../testdata/app_data/20210401/survey_data/"))
 lkups <- create_versioned_lkups(Sys.getenv("PIPAPI_DATA_ROOT_FOLDER"))
-lkups <-lkups$versions_paths[[lkups$latest_release]]
+lkup <- lkups$versions_paths[[lkups$latest_release]]
 
 test_that("Reporting level filtering is working", {
   reporting_levels <- c("national", "urban", "rural", "all")
@@ -20,7 +20,7 @@ test_that("Reporting level filtering is working", {
                       reporting_level = x,
                       fill_gaps = FALSE,
                       ppp = 10,
-                      lkup = lkups,
+                      lkup = lkup,
                       debug = FALSE)
                 })
   names(tmp) <- reporting_levels
@@ -39,8 +39,8 @@ test_that("Reporting level filtering is working", {
   })
 
 # Use only test data
-# lkups$svy_lkup <- lkups$svy_lkup[(cache_id %in% files | country_code == "AGO")]
-# lkups$ref_lkup <- lkups$ref_lkup[(cache_id %in% files | country_code == "AGO")]
+# lkup$svy_lkup <- lkup$svy_lkup[(cache_id %in% files | country_code == "AGO")]
+# lkup$ref_lkup <- lkup$ref_lkup[(cache_id %in% files | country_code == "AGO")]
 
 # Check output type ----
 test_that("output type is correct", {
@@ -48,7 +48,7 @@ test_that("output type is correct", {
     country = "all",
     year = "all",
     povline = 3.5,
-    lkup = lkups
+    lkup = lkup
   )
 
   expect_equal(class(tmp), c("data.table", "data.frame"))
@@ -56,17 +56,17 @@ test_that("output type is correct", {
 
 # Check empty response
 test_that("empty response is returned if no metadata is found", {
-  tmp <- pip("COL", year = 2050, lkup = lkups)
+  tmp <- pip("COL", year = 2050, lkup = lkup)
   expect_equal(nrow(tmp), 0)
-  tmp <- pip("COL", year = 2050, lkup = lkups, fill_gaps = TRUE)
+  tmp <- pip("COL", year = 2050, lkup = lkup, fill_gaps = TRUE)
   expect_equal(nrow(tmp), 0)
 })
 
 # Check response columns
 test_that("returned columns are the same for all non-group_by queries", {
-  tmp1 <- pip('AGO', 2000, lkup = lkups)
-  tmp2 <- pip('AGO', 2010, lkup = lkups, fill_gaps = TRUE)
-  tmp3 <- pip('AGO', 2050, lkup = lkups)
+  tmp1 <- pip('AGO', 2000, lkup = lkup)
+  tmp2 <- pip('AGO', 2010, lkup = lkup, fill_gaps = TRUE)
+  tmp3 <- pip('AGO', 2050, lkup = lkup)
   expect_identical(names(tmp1), names(tmp2))
   expect_identical(names(tmp1), names(tmp3))
   # skip("collapsed columns (e.g. survey_year, cpi) are converted to character")
@@ -84,9 +84,9 @@ test_that("year selection is working", {
     country = "AGO",
     year = "all",
     povline = 1.9,
-    lkup = lkups
+    lkup = lkup
   )
-  check <- sum(lkups$svy_lkup$country_code == "AGO")
+  check <- sum(lkup$svy_lkup$country_code == "AGO")
   expect_equal(nrow(tmp), check)
 
   # Most recent year for a single country
@@ -94,9 +94,9 @@ test_that("year selection is working", {
     country = "AGO",
     year = "mrv",
     povline = 1.9,
-    lkup = lkups
+    lkup = lkup
   )
-  check <- max(lkups$svy_lkup[country_code == "AGO"]$reporting_year)
+  check <- max(lkup$svy_lkup[country_code == "AGO"]$reporting_year)
   expect_equal(tmp$reporting_year, sum(check))
 
   # Most recent year for a single country (w/ fill_gaps)
@@ -105,9 +105,9 @@ test_that("year selection is working", {
     year = "mrv",
     povline = 1.9,
     fill_gaps = TRUE,
-    lkup = lkups
+    lkup = lkup
   )
-  check <- max(lkups$ref_lkup$reporting_year)
+  check <- max(lkup$ref_lkup$reporting_year)
   expect_equal(tmp$reporting_year, check)
 
   # Most recent year for all countries
@@ -115,9 +115,9 @@ test_that("year selection is working", {
     country = "all",
     year = "mrv",
     povline = 1.9,
-    lkup = lkups
+    lkup = lkup
   )
-  check <- max(lkups$svy_lkup$reporting_year)
+  check <- max(lkup$svy_lkup$reporting_year)
   expect_equal(unique(tmp$reporting_year), check)
 
 })
@@ -128,7 +128,7 @@ test_that("welfare_type selection are correct", {
     country = "all",
     year = "all",
     povline = 3.5,
-    lkup = lkups,
+    lkup = lkup,
     welfare_type = "all"
   )
 
@@ -138,7 +138,7 @@ test_that("welfare_type selection are correct", {
     country = "all",
     year = "all",
     povline = 3.5,
-    lkup = lkups,
+    lkup = lkup,
     welfare_type = "consumption"
   )
 
@@ -148,7 +148,7 @@ test_that("welfare_type selection are correct", {
     country = "all",
     year = "all",
     povline = 3.5,
-    lkup = lkups,
+    lkup = lkup,
     welfare_type = "income"
   )
 
@@ -161,7 +161,7 @@ test_that("reporting_level selection are correct", {
     country = "all",
     year = "all",
     povline = 3.5,
-    lkup = lkups,
+    lkup = lkup,
     reporting_level = "all"
   )
 
@@ -171,7 +171,7 @@ test_that("reporting_level selection are correct", {
     country = "all",
     year = "all",
     povline = 3.5,
-    lkup = lkups,
+    lkup = lkup,
     reporting_level = "national"
   )
 
@@ -181,7 +181,7 @@ test_that("reporting_level selection are correct", {
     country = "all",
     year = "all",
     povline = 3.5,
-    lkup = lkups,
+    lkup = lkup,
     reporting_level = "rural"
   )
 
@@ -191,7 +191,7 @@ test_that("reporting_level selection are correct", {
     country = "all",
     year = "all",
     povline = 3.5,
-    lkup = lkups,
+    lkup = lkup,
     reporting_level = "urban"
   )
 
@@ -206,7 +206,7 @@ test_that("Aggregation is working", {
     year = "all",
     povline = 3.5,
     aggregate = TRUE,
-    lkup = lkups
+    lkup = lkup
   )
   expect_equal(nrow(tmp), 1)
 })
@@ -218,7 +218,7 @@ test_that("Imputation is working", {
     year = "all",
     povline = 3.5,
     fill_gaps = TRUE,
-    lkup = lkups
+    lkup = lkup
   )
   # Why is this correct? E.g. tmp %>% group_by(country_code) %>% summarise(n = n())
   expect_equal(nrow(tmp), 195)
@@ -231,7 +231,7 @@ test_that("Imputation is working for mixed distributions aggregate / micro", {
     year = 1993,
     povline = 1.9,
     fill_gaps = TRUE,
-    lkup = lkups
+    lkup = lkup
   )
 
   expect_equal(nrow(tmp), 3)
@@ -247,7 +247,7 @@ test_that("Imputation is working for mixed distributions group / micro", {
     year = 2015,
     povline = 1.9,
     fill_gaps = TRUE,
-    lkup = lkups
+    lkup = lkup
   )
 
   expect_equal(nrow(tmp), 1)
@@ -262,7 +262,7 @@ test_that("imputation is working for extrapolated aggregate distribution", {
     year = 1988,
     povline = 1.9,
     fill_gaps = TRUE,
-    lkup = lkups
+    lkup = lkup
   )
 
   expect_equal(nrow(tmp), 3)
@@ -275,29 +275,29 @@ test_that("imputation is working for extrapolated aggregate distribution", {
 test_that("Distributional stats are correct for interpolated/extrapolated reporting years",{
 
   # Extrapolation (one year)
-  tmp1 <- pip("AGO", year = 1981, fill_gaps = TRUE, lkup = lkups)
-  tmp2 <- pip("AGO", year = 2000, fill_gaps = FALSE, lkup = lkups)
+  tmp1 <- pip("AGO", year = 1981, fill_gaps = TRUE, lkup = lkup)
+  tmp2 <- pip("AGO", year = 2000, fill_gaps = FALSE, lkup = lkup)
   expect_equal(tmp1$gini, tmp2$gini)
   expect_equal(tmp1$median, tmp2$median)
   expect_equal(tmp1$mld, tmp2$mld)
   expect_equal(tmp1$decile10, tmp2$decile10)
 
   # Interpolation (one year)
-  tmp1 <- pip("AGO", year = 2004, fill_gaps = TRUE, lkup = lkups)
+  tmp1 <- pip("AGO", year = 2004, fill_gaps = TRUE, lkup = lkup)
   expect_equal(tmp1$gini, NA_real_)
   expect_equal(tmp1$median ,NA_real_)
   expect_equal(tmp1$mld, NA_real_)
   expect_equal(tmp1$decile10, NA_real_)
 
   # Extrapolation (multiple years)
-  tmp1 <- pip("AGO", year = 1981:1999, fill_gaps = TRUE, lkup = lkups)
+  tmp1 <- pip("AGO", year = 1981:1999, fill_gaps = TRUE, lkup = lkup)
   expect_equal(unique(tmp1$gini), tmp2$gini)
   expect_equal(unique(tmp1$median), tmp2$median)
   expect_equal(unique(tmp1$mld), tmp2$mld)
   expect_equal(unique(tmp1$decile10), tmp2$decile10)
 
   # Interpolation (mulitiple year)
-  tmp1 <- pip("AGO", year = 2001:2007, fill_gaps = TRUE, lkup = lkups)
+  tmp1 <- pip("AGO", year = 2001:2007, fill_gaps = TRUE, lkup = lkup)
   expect_equal(unique(tmp1$gini), NA_real_)
   expect_equal(unique(tmp1$median), NA_real_)
   expect_equal(unique(tmp1$mld), NA_real_)
@@ -313,7 +313,7 @@ test_that("Regional aggregations are working", {
     year = "2000",
     group_by = "wb",
     povline = 3.5,
-    lkup = lkups
+    lkup = lkup
   )
 
   expect_equal(nrow(tmp), 3) # Should be changed if lkups are updated. Full set of regions is 8.
@@ -325,7 +325,7 @@ test_that("pop_share option is working", {
     country = "AGO",
     year = 2000,
     popshare = .2,
-    lkup = lkups
+    lkup = lkup
   )
 
   expect_equal(nrow(tmp), 1)
@@ -335,11 +335,11 @@ test_that("pop_share option is working", {
 
 test_that("pip country name case insensitive", {
   #Run it on pip-fake-data
-  tmp1 <- pip(country = "nga",year = "ALL", povline = 1.9, lkup = lkups)
-  tmp2 <- pip(country = "NGA",year = "all", povline = 1.9, lkup = lkups)
-  tmp3 <- pip(country = "All",year = "ALL", povline = 1.9, lkup = lkups)
-  tmp4 <- pip(country = "chn",year = "1981", povline = 1.9, lkup = lkups)
-  tmp5 <- pip(country = "chn",year = "ALL", povline = 1.9, lkup = lkups)
+  tmp1 <- pip(country = "nga",year = "ALL", povline = 1.9, lkup = lkup)
+  tmp2 <- pip(country = "NGA",year = "all", povline = 1.9, lkup = lkup)
+  tmp3 <- pip(country = "All",year = "ALL", povline = 1.9, lkup = lkup)
+  tmp4 <- pip(country = "chn",year = "1981", povline = 1.9, lkup = lkup)
+  tmp5 <- pip(country = "chn",year = "ALL", povline = 1.9, lkup = lkup)
 
   expect_equal(nrow(tmp1), 1)
   expect_equal(nrow(tmp2), 1)
@@ -352,7 +352,6 @@ test_that("pip country name case insensitive", {
 #Better error message when more than one data set is passed.
 
 test_that("error when more than one dataset is passed", {
-  lkups <- create_versioned_lkups(Sys.getenv("PIPAPI_DATA_ROOT_FOLDER"))
 
   expect_error(pip(country = "all", year = "all", povline = 1.9, lkup = lkups),
                "You are probably passing more than one dataset as lkup argument.

--- a/tests/testthat/test-pip.R
+++ b/tests/testthat/test-pip.R
@@ -335,11 +335,11 @@ test_that("pop_share option is working", {
 
 test_that("pip country name case insensitive", {
   #Run it on pip-fake-data
-  tmp1 <- pip(country = "nga",year = "ALL", povline = 1.9, lkup = lkup)
-  tmp2 <- pip(country = "NGA",year = "all", povline = 1.9, lkup = lkup)
-  tmp3 <- pip(country = "All",year = "ALL", povline = 1.9, lkup = lkup)
-  tmp4 <- pip(country = "chn",year = "1981", povline = 1.9, lkup = lkup)
-  tmp5 <- pip(country = "chn",year = "ALL", povline = 1.9, lkup = lkup)
+  tmp1 <- pip(country = "nga",year = "ALL", povline = 1.9, lkup = lkups)
+  tmp2 <- pip(country = "NGA",year = "all", povline = 1.9, lkup = lkups)
+  tmp3 <- pip(country = "All",year = "ALL", povline = 1.9, lkup = lkups)
+  tmp4 <- pip(country = "chn",year = "1981", povline = 1.9, lkup = lkups)
+  tmp5 <- pip(country = "chn",year = "ALL", povline = 1.9, lkup = lkups)
 
   expect_equal(nrow(tmp1), 1)
   expect_equal(nrow(tmp2), 1)
@@ -348,3 +348,14 @@ test_that("pip country name case insensitive", {
   expect_equal(nrow(tmp5), 6)
 })
 
+
+#Better error message when more than one data set is passed.
+
+test_that("error when more than one dataset is passed", {
+  lkups <- create_versioned_lkups(Sys.getenv("PIPAPI_DATA_ROOT_FOLDER"))
+
+  expect_error(pip(country = "all", year = "all", povline = 1.9, lkup = lkups),
+               "You are probably passing more than one dataset as lkup argument.
+  Try passing a single one by subsetting it lkup <- lkups$versions_paths$dataset_name_PROD",
+  fixed = TRUE)
+})

--- a/tests/testthat/test-plumber.R
+++ b/tests/testthat/test-plumber.R
@@ -186,7 +186,7 @@ test_that("Indicator names are correct", {
   r <- httr::GET(root_path, port = 8000, path = "api/v1/indicators")
   # Check response
   ind_resp <- httr::content(r, encoding = "UTF-8")
-  ind_code <- purrr::map_chr(ind_resp, "indicator_code")
+  ind_code <- y <- vapply(ind_resp, `[[`, "indicator_code", FUN.VALUE = character(1))
   expect_equal(sum(names(pip_resp[[1]]) %in% ind_code), 21)
 })
 

--- a/tests/testthat/test-ui_functions.R
+++ b/tests/testthat/test-ui_functions.R
@@ -50,7 +50,6 @@ test_that("ui_pc_charts() works as expected", {
   # Regular query (fill_gaps = TRUE)
   res <- ui_pc_charts(country = "AGO", povline = 1.9, fill_gaps = TRUE, lkup = lkups)
   expect_equal(nrow(res), length(unique(lkups$ref_lkup$reporting_year)))
-  expect_equal(length(names(res)), 12)
 
   # Group by
   res <- ui_pc_charts(country = "AGO", group_by = "wb", povline = 1.9, lkup = lkups)
@@ -315,7 +314,10 @@ test_that("ui_cp_charts() works as expected", {
 
     # All countries
   dl3 <- ui_cp_charts(country = "all", povline = 1.9, lkup = lkups)
-  expect_length(dl3, length(lkups$query_controls$country$values) - 1) # All countries
+  # Return non country iso3 codes
+  # lkups$query_controls$country$values[!lkups$query_controls$country$values %in% names(dl3)]
+  aggregate_country_codes <- 8
+  expect_length(dl3, length(lkups$query_controls$country$values) - aggregate_country_codes) # All countries
   expect_length(dl3[[2]], 5) # 5 chart objects (2 inside pov_charts)
   expect_length(dl3[[2]]$pov_charts, 1) # 1 poverty line
   expect_identical(names(dl3[[2]]), c(
@@ -335,42 +337,42 @@ test_that("ui_cp_charts() works as expected", {
 
 })
 
+test_that("ui_cp_charts() only returns first country if multiple countries are passed", {
+  # A single poverty line
+  dl1 <- ui_cp_charts(country = c("AGO", "AFG"), povline = 1.9, lkup = lkups)
+  expect_length(dl1, 1) # 1 country
+  expect_equal(names(dl1), "AGO")
+})
+
 test_that("ui_svy_meta() works as expected", {
+  expected_names <- c("country_code", "reporting_year" , "survey_year",
+                      "survey_title", "survey_conductor",  "survey_coverage",
+                      "welfare_type",    "distribution_type", "metadata")
+  expected_metadata <- c(
+    "surveyid_year", "survey_acronym",
+    "year_start", "year_end",
+    "authoring_entity_name", "abstract",
+    "collection_dates_cycle", "collection_dates_start",
+    "collection_dates_end", "sampling_procedure",
+    "collection_mode", "coll_situation", "weight",
+    "cleaning_operations"
+  )
+
   res <- ui_svy_meta(country = "AGO", lkup = lkups)
   expect_equal(unique(res$country_code), "AGO")
   expect_equal(names(res),
-               c("country_code", "reporting_year" ,
-                 "survey_title", "survey_conductor",  "survey_coverage",
-                 "welfare_type",    "distribution_type", "metadata"))
+               expected_names)
   expect_equal(
     names(res$metadata[[1]]),
-    c(
-      "surveyid_year", "survey_acronym",
-      "year_start", "year_end",
-      "authoring_entity_name", "abstract",
-      "collection_dates_cycle", "collection_dates_start",
-      "collection_dates_end", #"survey_coverage",
-      "sampling_procedure", "collection_mode",
-      "coll_situation", "weight", "cleaning_operations"
-    )
+    expected_metadata
   )
   res <- ui_svy_meta(country = "all", lkup = lkups)
   expect_true(all(unique(res$country_code) %in%
                     lkups$query_controls$country$values))
   expect_equal(names(res),
-               c("country_code", "reporting_year" ,
-                 "survey_title", "survey_conductor",  "survey_coverage",
-                 "welfare_type",    "distribution_type", "metadata"))
+               expected_names)
   expect_equal(
     names(res$metadata[[1]]),
-    c(
-      "surveyid_year", "survey_acronym",
-      "year_start", "year_end",
-      "authoring_entity_name", "abstract",
-      "collection_dates_cycle", "collection_dates_start",
-      "collection_dates_end", #"survey_coverage",
-      "sampling_procedure", "collection_mode",
-      "coll_situation", "weight", "cleaning_operations"
-    )
+    expected_metadata
   )
 })


### PR DESCRIPTION
@tonyfujs I am using length of dataset as a differentiating factor. When there is more than one dataset the list has 3 elements `versions`, `versions_paths` and `latest_release`. For safer side I am comparing it with `<= 5` in case if we decide to add more values in the future. The single dataset has length much higher (13).  Do you have any other suggestion to compare? 

Also, let me know if there is a better message that you can think of than what I have suggested. 

- Added test case for the same. 
- Fixed a typo in the previous test case for case insensitivity. 

