### PR TITLE
serialize output of v1/versions endpoint

### DIFF
--- a/inst/plumber/v1/endpoints.R
+++ b/inst/plumber/v1/endpoints.R
@@ -142,8 +142,10 @@ function() {
 
 #* Return available data versions
 #* @get /api/v1/versions
+#* @serializer switch
 function(req) {
   out <- pipapi::version_dataframe(lkups$versions)
+  attr(out, "serialize_format") <- req$argsQuery$format
   out
 }
 


### PR DESCRIPTION
Hi Tony, 

I think this is all that is needed for the versions table to be properly serialized to csv format. I need this feature to be working soon because the GPID team is waiting for it to keep going with their work. 

Thanks.

@tonyfujs 