### PR TITLE
Fix issue with WLD input

### DIFF
--- a/R/create_countries_vctr.R
+++ b/R/create_countries_vctr.R
@@ -60,7 +60,7 @@ create_countries_vctr <- function(country,
                   region_code]
 
   #  Aggregates selected by user
-  if ("all" %in% country) {
+  if (any(c("all", "WLD") %in% country)) {
     user_aggs <- off_reg
   } else {
     user_aggs <- aggs[region_code %in% country,

--- a/inst/plumber/v1/endpoints.R
+++ b/inst/plumber/v1/endpoints.R
@@ -142,8 +142,10 @@ function() {
 
 #* Return available data versions
 #* @get /api/v1/versions
+#* @serializer switch
 function(req) {
   out <- pipapi::version_dataframe(lkups$versions)
+  attr(out, "serialize_format") <- req$argsQuery$format
   out
 }
 


### PR DESCRIPTION
Hi @tonyfujs, 

This should close #266
See example below.
Best, 

CC: @shahronak47 

```r
R> ccv <- 
+   create_countries_vctr(country = "WLD",
+                       year = "all",
+                       lkup = lkup)
R> ccv$est_ctrs
#>  [1] "AGO" "ALB" "ARE" "ARG" "ARM" "AUS" "AUT" "AZE" "BDI" "BEL" "BEN" "BFA"
#> [13] "BGD" "BGR" "BIH" "BLR" "BLZ" "BOL" "BRA" "BTN" "BWA" "CAF" "CAN" "CHE"
#> .... more values
#> [157] "UKR" "URY" "USA" "UZB" "VEN" "VNM" "VUT" "WSM" "XKX" "YEM" "ZAF" "ZMB"
#> [169] "ZWE"

R> pip_grp_logic(
+   country = "WLD",
+   year = 2015,
+   povline = 1.9,
+   lkup = lkup
+   ) 
#>   region_name region_code reporting_year reporting_pop poverty_line   headcount
#> 1:       World         WLD           2015    7347679005          1.9 0.068298288
#>   poverty_gap poverty_severity       watts      mean pop_in_poverty
#> 1: 0.020010519     0.0091983646 0.028017372 16.533493      501833894

R> pip(
+   country = "WLD",
+   year = 2015,
+   povline = 1.9,
+   lkup = lkup
+   ) 
#>                     region_name region_code       country_name country_code
#>  1:       Europe & Central Asia         ECA            Albania          ALB
#>  2:       Europe & Central Asia         ECA            Armenia          ARM
#>  3: Other High Income Countries         OHI            Austria          AUT
#>  .... more rows... 

```



