### PR TITLE
make default poverty line dynamic

### DIFF
--- a/R/utils-plumber.R
+++ b/R/utils-plumber.R
@@ -188,10 +188,11 @@ serializer_switch <- function() {
 #' Assign PIP API required parameters if missing
 #'
 #' @param req list: plumber `req` object
+#' @param pl_lkup data.frame: Poverty lines lookup table
 #'
 #' @return list
 #' @noRd
-assign_required_params <- function(req) {
+assign_required_params <- function(req, pl_lkup) {
 
   # Handle required names for /pip endpoint
   endpoint <- extract_endpoint(req$PATH_INFO)
@@ -216,6 +217,22 @@ assign_required_params <- function(req) {
     # Turn all year codes to upper case
     req$args$year <- toupper(req$args$year)
     req$argsQuery$year <- toupper(req$argsQuery$year)
+  }
+
+  # Handle default poverty line
+  if (endpoint %in% c("pip",
+                      "pip-grp",
+                      "hp-stacked",
+                      "pc-charts",
+                      "pc-download",
+                      "pc-regional-aggregates",
+                      "cp-key-indicators",
+                      "cp-charts",
+                      "cp-download")) {
+    if (is.null(req$args$povline)) {
+      req$args$povline <- pl_lkup$poverty_line[pl_lkup$is_default == TRUE]
+      req$argsQuery$povline <- pl_lkup$poverty_line[pl_lkup$is_default == TRUE]
+    }
   }
   return(req)
 }

--- a/inst/plumber/v1/endpoints.R
+++ b/inst/plumber/v1/endpoints.R
@@ -62,11 +62,15 @@ function(req, res) {
   if (req$QUERY_STRING != "" & !grepl("swagger", req$PATH_INFO)) {
     # STEP 1: Assign required parameters
     # Non-provided parameters are typically assigned the underlying function
-    # arguments' default values. There is an exception to that however:
-    # The `country` & `year` parameters cannot be NULL in order for to pass
+    # arguments' default values. There are two exceptions to that however:
+    # 1) The `country` & `year` parameters cannot be NULL in order for to pass
     # the if condition that will decide whether or no the request should be
     # treated asynchronously.
-    req <- pipapi:::assign_required_params(req)
+    # 2) The introduction of PPP versioning implies having a dynamic default
+    # poverty line
+
+    req <- pipapi:::assign_required_params(req,
+                                           pl_lkup = lkups$pl_lkup)
 
     # STEP 2: Validate individual query parameters
     are_valid <- pipapi:::check_parameters(req, query_controls)

--- a/tests/testthat/test-utils-plumber.R
+++ b/tests/testthat/test-utils-plumber.R
@@ -11,6 +11,9 @@ if (Sys.getenv("PIPAPI_DATA_ROOT_FOLDER_LOCAL") != "") {
 
 }
 
+pl_lkup <- lkups$pl_lkup
+poverty_line <- pl_lkup$poverty_line[pl_lkup$is_default == TRUE]
+
 test_that("validate_query_parameters() works", {
 
   # Test that all pip() parameters are accepted
@@ -201,25 +204,29 @@ test_that("assign_required_params works as expected for /pip endpoint", {
 
   req <- list()
   req$PATH_INFO <- "api/v1/pip"
-  req <- assign_required_params(req)
+  req <- assign_required_params(req, pl_lkup)
 
   expect_identical(req$args$country, "ALL")
   expect_identical(req$args$year, "ALL")
+  expect_identical(req$args$povline, poverty_line)
   expect_identical(req$argsQuery$country, "ALL")
   expect_identical(req$argsQuery$year, "ALL")
+  expect_identical(req$argsQuery$povline, poverty_line)
 })
 
 test_that("assign_required_params works as expected for /pip-grp endpoint", {
 
   req <- list()
   req$PATH_INFO <- "api/v1/pip-grp"
-  req <- assign_required_params(req)
+  req <- assign_required_params(req, pl_lkup)
 
   expect_identical(req$args$country, "ALL")
   expect_identical(req$args$year, "ALL")
+  expect_identical(req$args$povline, poverty_line)
   expect_identical(req$args$group_by, "none")
   expect_identical(req$argsQuery$country, "ALL")
   expect_identical(req$argsQuery$year, "ALL")
+  expect_identical(req$argsQuery$povline, poverty_line)
   expect_identical(req$argsQuery$group_by, "none")
 })
 

--- a/tests/testthat/test-valid_years.R
+++ b/tests/testthat/test-valid_years.R
@@ -1,7 +1,7 @@
 skip_if(Sys.getenv("PIPAPI_DATA_ROOT_FOLDER_LOCAL") == "")
 
 # constants
-tdir <- fs::path(Sys.getenv("PIPAPI_DATA_ROOT_FOLDER_LOCAL"), "20220810_2017_01_02_PROD")
+tdir <- fs::dir_ls(Sys.getenv("PIPAPI_DATA_ROOT_FOLDER_LOCAL"))[1]
 
 test_that("valid_years returns expected output type", {
 


### PR DESCRIPTION
Now that PPP versioning is available, the default poverty line needs to be assigned dynamically
