### PR TITLE
Homepage up to 2019

### DIFF
--- a/R/ui_functions.R
+++ b/R/ui_functions.R
@@ -11,7 +11,7 @@ ui_hp_stacked <- function(povline = 1.9,
                           lkup) {
 
   ref_years <- sort(unique(lkup$ref_lkup$reporting_year))
-  ref_years <- ref_years[!ref_years %in% c(1981:1990, 2019)]
+  ref_years <- ref_years[!ref_years %in% c(1981:1990)]
 
   out <- pip_grp(
     country = "all",


### PR DESCRIPTION
Hi Tony,

We need to include this fix urgently because homepage should be up to 2019 and right now it is up to 2018. It was hardcoded in the past.

Thanks.
Best,