### PR TITLE
Hot fix cp download

### DIFF
--- a/R/ui_functions.R
+++ b/R/ui_functions.R
@@ -602,29 +602,19 @@ ui_cp_download_single <- function(country,
                                   povline = 1.9,
                                   lkup) {
 
+
   hc <- ui_cp_ki_headcount(country, year, povline, lkup)
 
-  # Remove "shared_prosperity" since the column names are not consistent with the
-  # other data frames
-  indicators <- lkup$cp$key_indicators[!names(lkup$cp$key_indicators) %in% c("shared_prosperity", "reporting_pop")]
-  dl <- lapply(indicators, function(x) {
-    out <- x[country_code == country, ]
-    out[["latest"]] <- NULL
-    out <- unique(out) # HOT FIX: NEED TO FIGURE OUT WHAT THE REAL ISSUE IS
-    return(out)
-  })
-
-  dl <- c(headcount = list(hc), dl)
-
-  out <- Reduce(function(df1, df2) {
-    merge(df1, df2,
+  df <- lkup$cp$flat$flat_cp
+  df <- df[country_code == country]
+  out <-
+    merge(hc, df,
           by = c("country_code", "reporting_year"),
           all = TRUE)
-  },
-  dl)
 
   # Re-scale headcount_national to be consistent with headcount
-  out$headcount_national <- out$headcount_national / 100
+  out[, headcount_national := headcount_national / 100]
+
 
   return(out)
 }

--- a/R/ui_functions.R
+++ b/R/ui_functions.R
@@ -590,33 +590,3 @@ ui_cp_download <- function(country = "AGO",
   return(out)
 }
 
-
-
-#' Country Profile Key Indicators download
-#'
-#' Helper function to download Country Profile data
-#'
-#' @inheritParams ui_cp_download
-#' @return list
-#' @keywords internal
-ui_cp_download_single <- function(country,
-                                  year,
-                                  povline = 1.9,
-                                  lkup) {
-
-
-  hc <- ui_cp_ki_headcount(country, year, povline, lkup)
-
-  df <- lkup$cp$flat$flat_cp
-  df <- df[country_code == country]
-  out <-
-    merge(hc, df,
-          by = c("country_code", "reporting_year"),
-          all = TRUE)
-
-  # Re-scale headcount_national to be consistent with headcount
-  out[, headcount_national := headcount_national / 100]
-
-
-  return(out)
-}


### PR DESCRIPTION
# Prework

* [x] I understand and agree to the [contributing guidelines](https://github.com/PIP-Technical-Team/pipapi/blob/master/CONTRIBUTING.md).
* [x] I have already submitted an [issue](https://github.com/PIP-Technical-Team/pipapi/issues) to discuss my idea with the maintainer.

# Related GitHub issues and pull requests

* Ref: #327 

# Summary

Hi @tonyfujs,

The data downloaded in the country profile page is currently wrong. For the selected country or for all the countries option it is only returning the international poverty headcount. Minh shared with us a flat file with 46 variables than need to be returned. I have fix the returning data in this PR.  The interaction with the main function, `ui_cp_download()`, remains unchanged, but the logic inside has change to not only read the new data but to make the calculations of all countries more efficient. Use the code below with the current version and then with this branch to see the difference in output. 

Best, 

![image](https://user-images.githubusercontent.com/35301997/217864610-8afb3220-4e2f-4333-9f90-b5e1f8e57ec1.png)

 

```r
# constants
lkups <- create_versioned_lkups(Sys.getenv("PIPAPI_DATA_ROOT_FOLDER_SERVER"), 
                                vintage_pattern = "20220909")
lkup <- lkups$versions_paths[[lkups$latest_release]]


country <- "COL"
year    <- "ALL"
povline <- 2.15

df <- ui_cp_download(country,
                     year,
                     povline,
                     lkup)


df2 <- ui_cp_download("ALL",
                     year,
                     povline,
                     lkup)

```