### PR TITLE
Fix issues with long_format

### DIFF
--- a/R/get_aux_table.R
+++ b/R/get_aux_table.R
@@ -22,13 +22,14 @@ get_aux_table <- function(data_dir, table, long_format = FALSE) {
   out <- fst::read_fst(sprintf(
     "%s/_aux/%s.fst",
     data_dir,
-    sanitized_table
-  ))
-
-  out <- data.table::data.table(out)
+    sanitized_table),
+    as.data.table = TRUE)
 
   if (long_format) {
-    out <- data.table::melt(out, id.vars = c('country_code', 'data_level'), variable.name = "year")
+    out <- data.table::melt(out,
+                            id.vars = c('country_code', 'data_level'),
+                            variable.name = "year")
+    data.table::setorder(out, country_code, year, data_level)
   }
 
   return(out)

--- a/R/utils-plumber.R
+++ b/R/utils-plumber.R
@@ -241,6 +241,32 @@ assign_required_params <- function(req, pl_lkup) {
       req$argsQuery$povline <- pl_lkup$poverty_line[pl_lkup$is_default == TRUE]
     }
   }
+
+  # Handle long_format argument for /aux endpoint
+  # Behavior: long_format argument will be forced to FALSE is the selected
+  # table is not suppported for long format
+  # Long format of tables
+  if (endpoint == "aux") {
+    # If no table is defined
+    if (is.null(req$argsQuery$table)) {
+      req$argsQuery$long_format <- FALSE
+    }
+
+    # If long format is not selected
+    if (is.null(req$argsQuery$long_format)) {
+
+      # Check if belongs to list of tables available in long format
+      if (req$argsQuery$table %in%
+          pipapi::get_valid_aux_long_format_tables()) {
+        req$argsQuery$long_format <- TRUE
+      } else {
+        req$argsQuery$long_format <- FALSE
+      }
+      # end of if NULL long_format
+    } else {
+      req$argsQuery$long_format <- as.logical(req$argsQuery$long_format)
+    }
+  }
   return(req)
 }
 

--- a/inst/TMP/TMP_API_launcher.R
+++ b/inst/TMP/TMP_API_launcher.R
@@ -1,4 +1,4 @@
-lkups <- pipapi::create_versioned_lkups(Sys.getenv('PIPAPI_DATA_ROOT_FOLDER'))
+# lkups <- pipapi::create_versioned_lkups(Sys.getenv('PIPAPI_DATA_ROOT_FOLDER'))
 
 start_api(api_version = "v1",
           port = 80,

--- a/inst/plumber/v1/endpoints.R
+++ b/inst/plumber/v1/endpoints.R
@@ -123,8 +123,7 @@ function(req, res) {
           res$status <- 404
           out <- list(
             error = "Invalid query arguments have been submitted.",
-            details = list(msg = "The selected table is not available in
-                         long format. Please select one of the valid values",
+            details = list(msg = "The selected table is not available in long format. Please select one of the valid values",
                          valid = pipapi::get_valid_aux_long_format_tables()))
           return(out)
         }

--- a/inst/plumber/v1/endpoints.R
+++ b/inst/plumber/v1/endpoints.R
@@ -11,30 +11,39 @@ library(pipapi)
 function(req, res) {
 
   # STEP 1 - If no arguments are passed, use the latest version
-  if (is.null(req$argsQuery$release_version) & is.null(req$argsQuery$ppp_version) &
-     is.null(req$argsQuery$version) & is.null(req$argsQuery$identity)) {
+  if (is.null(req$argsQuery$release_version) &
+      is.null(req$argsQuery$ppp_version) &
+      is.null(req$argsQuery$version) &
+      is.null(req$argsQuery$identity)) {
       version <- lkups$latest_release
-  # STEP 2 - If partial version information is passed, use selection algorithm
   } else {
+  # STEP 2 - If partial version information is passed, use selection algorithm
     if (is.null(req$argsQuery$identity)) req$argsQuery$identity <- 'PROD'
-    version <- pipapi::return_correct_version(req$argsQuery$version,
-                                              req$argsQuery$release_version,
-                                              req$argsQuery$ppp_version,
-                                              req$argsQuery$identity, lkups$versions)
+    version <-
+      pipapi::return_correct_version(req$argsQuery$version,
+                                     req$argsQuery$release_version,
+                                     req$argsQuery$ppp_version,
+                                     req$argsQuery$identity, lkups$versions)
   }
-    # If the version is not found (404) or it is not present in valid versions vector return an error.
+    # If the version is not found (404) or it is not present in valid versions
+    # vector return an error.
     if (!version %in% lkups$versions) {
         res$status <- 404
         out <- list(
           error = "Invalid query arguments have been submitted.",
-          details = list(msg = "The selected value is not available. Please select one of the valid values",
+          details = list(msg = "The selected value is not available.
+                         Please select one of the valid values",
                          valid = pipapi::version_dataframe(lkups$versions)))
         return(out)
     } else req$argsQuery$version <- version
 
   if (pipapi:::extract_endpoint(req$PATH_INFO) == "aux") {
+    if (is.null(req$argsQuery$long_format)) {
+      req$argsQuery$long_format <- TRUE
+    }
     req$argsQuery$long_format <- as.logical(req$argsQuery$long_format)
-    if (isTRUE(req$argsQuery$long_format ) & !req$argsQuery$table %in% pipapi::get_valid_aux_long_format_tables()) {
+    if (isTRUE(req$argsQuery$long_format ) &
+        !req$argsQuery$table %in% pipapi::get_valid_aux_long_format_tables()) {
         # res$status <- 404
         # out <- list(
         #   error = "Invalid query arguments have been submitted.",


### PR DESCRIPTION
Hi @tonyfujs , 

I made some modifications to the endpoints.R file because it was still failing. The main changes are in what I call "STEP 3" following the same order that the script already had in the `#* @filter validate_version` function. This is what it does. 

1.  It check if the `table` parameter is NULL. If it is, the parameter `long_format` will `FALSE` by default. 
2. It checks if `long_format` is NULL. if it is, then if forces it to be `TRUE` if the `table` is one of `pipapi::get_valid_aux_long_format_tables()`, and `FALSE` otherwise. 
3. if `long_format` is NOT null, then it transforms it with `as.logical()` 
4. the Error that you commented to make the fix is functional now. So, I uncommented it. 

It is working fine now, but Please modify it as you think is best.

Andres. 