### PR TITLE
Fix long format return reorg

### DIFF
--- a/R/utils-plumber.R
+++ b/R/utils-plumber.R
@@ -241,6 +241,32 @@ assign_required_params <- function(req, pl_lkup) {
       req$argsQuery$povline <- pl_lkup$poverty_line[pl_lkup$is_default == TRUE]
     }
   }
+
+  # Handle long_format argument for /aux endpoint
+  # Behavior: long_format argument will be forced to FALSE is the selected
+  # table is not suppported for long format
+  # Long format of tables
+  if (endpoint == "aux") {
+    # If no table is defined
+    if (is.null(req$argsQuery$table)) {
+      req$argsQuery$long_format <- FALSE
+    }
+
+    # If long format is not selected
+    if (is.null(req$argsQuery$long_format)) {
+
+      # Check if belongs to list of tables available in long format
+      if (req$argsQuery$table %in%
+          pipapi::get_valid_aux_long_format_tables()) {
+        req$argsQuery$long_format <- TRUE
+      } else {
+        req$argsQuery$long_format <- FALSE
+      }
+      # end of if NULL long_format
+    } else {
+      req$argsQuery$long_format <- as.logical(req$argsQuery$long_format)
+    }
+  }
   return(req)
 }
 

--- a/inst/plumber/v1/endpoints.R
+++ b/inst/plumber/v1/endpoints.R
@@ -123,8 +123,7 @@ function(req, res) {
           res$status <- 404
           out <- list(
             error = "Invalid query arguments have been submitted.",
-            details = list(msg = "The selected table is not available in
-                         long format. Please select one of the valid values",
+            details = list(msg = "The selected table is not available in long format. Please select one of the valid values",
                          valid = pipapi::get_valid_aux_long_format_tables()))
           return(out)
         }


### PR DESCRIPTION
Hi @randrescastaneda 

I made a few changes to your PR, and created a new branch from yours so it is easier to see what I have modified:
1. I have kept the logic you've implemented
2. But I reorganized the code
    - I realized that in the original implmentation, the code to handle `long_format` was misplaced under the filter that handles the `version`. I moved this under the filter that handles parameter values. 
    - I moved the code that assigns specific TRUE/FALSE values to `long_format` in the `assign_required_params()` function

More importantly:
1. The changes you've made have changed the logic of the API compared to the current behavior in PROD. Now, the five supported tables are returned by default in `long_format`. **This will break the UI**. I've kept your logic for now because I saw you have already circulated an email about the new Stata wrapper behavior, but this will be an issue. Not necessarily a big one, but we will need to coordinate with ITS to ensure everything works smoothly. We can either revert back to previous behavior with breaking changes for the Stata wrapper users, or coordinate with ITS to implement the changes. Let's try to connect briefly today to discuss.
2. In some cases, the API still returns error messages when an invalid combination of table and long_format is being passed. I thougth this is what you wanted to avoid, so I'm flagging it. I guess it is no longer important since tables are being returned in long format by default now.