### PR TITLE
clean-up-duckdb

### DIFF
--- a/R/duckdb_func.R
+++ b/R/duckdb_func.R
@@ -208,6 +208,7 @@ update_master_file <- function(dat,
   "))
 
   duckdb::dbDisconnect(write_con)
+  invisible(gc())
   if (nr > 0 && verbose)  message(glue("{target_file} is updated."))
 
   return(nr)
@@ -275,6 +276,7 @@ reset_cache <- function(pass = Sys.getenv('PIP_CACHE_LOCAL_KEY'),
     DBI::dbExecute(write_con, "DELETE from fg_master_file")
   }
   duckdb::dbDisconnect(write_con)
+  invisible(gc())
 }
 
 create_duckdb_file <- function(cache_file_path) {
@@ -302,6 +304,7 @@ create_duckdb_file <- function(cache_file_path) {
                  watts     DOUBLE
   )")
   DBI::dbDisconnect(con)
+  invisible(gc())
 }
 
 

--- a/R/pip.R
+++ b/R/pip.R
@@ -146,7 +146,16 @@ pip <- function(country         = "ALL",
       out <- main_data |>
         rowbind(cached_data)
 
+      pl <- c(seq(from = 0.01, to = 5, by = 0.01),
+              seq(from = 5.1, to = 20, by = 0.1),
+              seq(from = 21, to = 100, by = 1),
+              seq(from = 105, to = 900, by = 5))
+      # Only update master file if poverty line is part of this pl list
+      # Using round to avoid precision error with decimals
+      if (all(round(povline, 2) %in% round(pl, 2))) {
         update_master_file(main_data, cache_file_path, fill_gaps)
+      }
+
 
     } else {
       out <- cached_data


### PR DESCRIPTION
Implement `gc()` for duckdb. Also added list of poverty lines to check before updating master file. 